### PR TITLE
Uppdatera en skickad underlagsförfrågan + meddela kund

### DIFF
--- a/index.js
+++ b/index.js
@@ -5671,7 +5671,7 @@ async function ensureSamarbeteArkiveradField(airtableToken, baseId, tableId) {
  * Kräver SMTP i .env: SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, MAIL_FROM (t.ex. "ClientFlow <underlag@clientflow.se>").
  */
 async function sendSamarbeteInviteEmail(options) {
-  const { toEmail, toName, senderName, senderEmail, senderByra, senderLogoUrl, respondUrl, title, customerMessage, deadlineDate } = options;
+  const { toEmail, toName, senderName, senderEmail, senderByra, senderLogoUrl, respondUrl, title, customerMessage, deadlineDate, isUpdate } = options;
   const host = (process.env.SMTP_HOST || '').trim();
   const user = (process.env.SMTP_USER || '').trim();
   const passRaw = process.env.SMTP_PASS ?? process.env.SMTP_PASSWORD;
@@ -5694,9 +5694,17 @@ async function sendSamarbeteInviteEmail(options) {
   const safeToName = escapeHtml(String(toName || 'Kund'));
   const safeSenderName = escapeHtml(String(senderName || 'Vi'));
   const safeSenderByra = escapeHtml(String(senderByra || '').trim());
-  const senderLine = safeSenderByra
-    ? `${safeSenderName} på ${safeSenderByra} har bett dig lämna underlag eller besvara frågor via ClientFlow.`
-    : `${safeSenderName} har bett dig lämna underlag eller besvara frågor via ClientFlow.`;
+  const senderLine = isUpdate
+    ? (safeSenderByra
+        ? `${safeSenderName} på ${safeSenderByra} har uppdaterat en underlagsförfrågan till dig i ClientFlow. Du använder samma länk som tidigare – dina eventuella svar finns kvar.`
+        : `${safeSenderName} har uppdaterat en underlagsförfrågan till dig i ClientFlow. Du använder samma länk som tidigare – dina eventuella svar finns kvar.`)
+    : (safeSenderByra
+        ? `${safeSenderName} på ${safeSenderByra} har bett dig lämna underlag eller besvara frågor via ClientFlow.`
+        : `${safeSenderName} har bett dig lämna underlag eller besvara frågor via ClientFlow.`);
+  const updateNoticeHtml = isUpdate
+    ? `<p style="margin:0 0 16px 0; font-size:1rem; line-height:1.5; color:#0f172a; font-weight:600;">Din underlagsförfrågan har uppdaterats.</p>`
+    : '';
+  const ctaLabel = isUpdate ? 'Öppna länk och se uppdateringen' : 'Öppna länk och lämna underlag';
   const rawName = String(senderName || 'Vi').trim();
   const rawByra = String(senderByra || '').trim();
   const subjectLine = rawByra ? `${rawName}, ${rawByra}` : rawName;
@@ -5741,6 +5749,7 @@ async function sendSamarbeteInviteEmail(options) {
           <tr>
             <td style="padding:28px;">
               <p style="margin:0 0 16px 0; font-size:1rem; line-height:1.5; color:#334155;">Hej ${safeToName},</p>
+              ${updateNoticeHtml}
               <p style="margin:0 0 20px 0; font-size:1rem; line-height:1.5; color:#475569;">${senderLine}</p>
               ${customerMessageHtml}
               ${deadlineHtml}
@@ -5748,7 +5757,7 @@ async function sendSamarbeteInviteEmail(options) {
               <table role="presentation" cellspacing="0" cellpadding="0" style="margin:0 auto;">
                 <tr>
                   <td style="border-radius:8px; background:#6366f1;">
-                    <a href="${respondUrl}" style="display:inline-block; padding:14px 28px; font-size:1rem; font-weight:600; color:#fff; text-decoration:none;">Öppna länk och lämna underlag</a>
+                    <a href="${respondUrl}" style="display:inline-block; padding:14px 28px; font-size:1rem; font-weight:600; color:#fff; text-decoration:none;">${ctaLabel}</a>
                   </td>
                 </tr>
               </table>
@@ -5781,15 +5790,20 @@ async function sendSamarbeteInviteEmail(options) {
       transporterOpts.requireTLS = true;
     }
     const transporter = nodemailer.createTransport(transporterOpts);
-    const textSenderLine = safeSenderByra
-      ? `${safeSenderName} på ${safeSenderByra} har bett dig lämna underlag via ClientFlow.`
-      : `${safeSenderName} har bett dig lämna underlag via ClientFlow.`;
+    const textSenderLine = isUpdate
+      ? (safeSenderByra
+          ? `${safeSenderName} på ${safeSenderByra} har uppdaterat en underlagsförfrågan till dig via ClientFlow. Du använder samma länk som tidigare – dina eventuella svar finns kvar.`
+          : `${safeSenderName} har uppdaterat en underlagsförfrågan till dig via ClientFlow. Du använder samma länk som tidigare – dina eventuella svar finns kvar.`)
+      : (safeSenderByra
+          ? `${safeSenderName} på ${safeSenderByra} har bett dig lämna underlag via ClientFlow.`
+          : `${safeSenderName} har bett dig lämna underlag via ClientFlow.`);
+    const textIntro = isUpdate ? 'Din underlagsförfrågan har uppdaterats.\n\n' : '';
     await transporter.sendMail({
       from,
       to: toEmail,
       replyTo: senderEmail || undefined,
-      subject: `Lämna underlag – från ${subjectLine}`,
-      text: `Hej ${safeToName},\n\n${textSenderLine}\n${deadlineStr ? `\nDeadline: ${deadlineStr}\n` : '\n'}\nÖppna denna länk för att lämna underlag eller besvara frågor:\n${respondUrl}\n\nMed vänliga hälsningar,\nClientFlow`,
+      subject: isUpdate ? `Din underlagsförfrågan har uppdaterats – från ${subjectLine}` : `Lämna underlag – från ${subjectLine}`,
+      text: `Hej ${safeToName},\n\n${textIntro}${textSenderLine}\n${deadlineStr ? `\nDeadline: ${deadlineStr}\n` : '\n'}\nÖppna denna länk för att lämna underlag eller besvara frågor:\n${respondUrl}\n\nMed vänliga hälsningar,\nClientFlow`,
       html
     });
     return { sent: true };
@@ -7684,6 +7698,192 @@ app.post('/api/samarbete/requests/:requestId/send', authenticateToken, async (re
     const msg = error.response?.data?.error?.message || error.message;
     console.error('POST /api/samarbete/requests/:requestId/send:', msg);
     res.status(error.response?.status === 404 ? 404 : 500).json({ error: msg });
+  }
+});
+
+// PUT /api/samarbete/requests/:requestId/update – uppdatera en redan skickad förfrågan (frågor/deadline)
+// och meddela kunden via mejl. Samma token/länk behålls och redan inlämnade svar bevaras.
+// Body: { title (radseparerade frågor), deadline?, customerMessage?, answerMapping?: (number|null)[], notify?: boolean }
+//  - answerMapping[nyIndex] = ursprungligt radindex (eller null för en ny fråga) så att svaren förblir
+//    rättinriktade mot frågorna även när frågor läggs till, tas bort eller flyttas.
+app.put('/api/samarbete/requests/:requestId/update', authenticateToken, async (req, res) => {
+  try {
+    const requestId = (req.params.requestId || '').trim();
+    if (!requestId) return res.status(400).json({ error: 'requestId krävs' });
+    const { title, deadline, customerMessage, answerMapping, notify } = req.body || {};
+    if (title == null || !String(title).trim()) return res.status(400).json({ error: 'title krävs' });
+
+    const airtableAccessToken = process.env.AIRTABLE_ACCESS_TOKEN;
+    const airtableBaseId = process.env.AIRTABLE_BASE_ID || 'appPF8F7VvO5XYB50';
+    if (!airtableAccessToken) return res.status(500).json({ error: 'Airtable token saknas' });
+
+    const tableId = await getSamarbeteTableId(airtableAccessToken, airtableBaseId);
+    if (!tableId) return res.status(404).json({ error: 'Tabellen Samarbete hittades inte' });
+
+    const recRes = await axios.get(
+      `https://api.airtable.com/v0/${airtableBaseId}/${tableId}/${requestId}`,
+      { headers: { Authorization: `Bearer ${airtableAccessToken}` } }
+    );
+    const record = recRes.data;
+    const fields = record.fields || {};
+    const customerId = fields['Kund ID'] || (fields['Kund'] && fields['Kund'][0]);
+    if (!customerId) return res.status(404).json({ error: 'Förfrågan hittades inte' });
+
+    // Avslutade/stängda förfrågningar är inte redigerbara – återöppna dem först.
+    if (fields['Stängd']) {
+      return res.status(409).json({ error: 'Förfrågan är avslutad och kan inte uppdateras. Återöppna den först om du vill ändra den.' });
+    }
+
+    const userData = await getAirtableUser(req.user.email);
+    if (!userData) return res.status(404).json({ error: 'Användare hittades inte' });
+    const custRes = await axios.get(
+      `https://api.airtable.com/v0/${airtableBaseId}/${KUNDDATA_TABLE_ID}/${customerId}`,
+      { headers: { Authorization: `Bearer ${airtableAccessToken}` } }
+    );
+    const cf = custRes.data.fields || {};
+    const custByraId = (cf['Byrå ID'] || cf.Byrå || '').toString();
+    if (userData.role !== 'ClientFlowAdmin' && String(custByraId) !== String(userData.byraId || '').trim()) {
+      return res.status(403).json({ error: 'Ingen behörighet' });
+    }
+
+    const parseDeadlineDateOnly = (v) => {
+      if (v == null) return null;
+      const s = String(v).trim();
+      if (!s) return null;
+      const m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+      if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+      const d = new Date(s);
+      if (Number.isNaN(d.getTime())) return null;
+      return d.toISOString().slice(0, 10);
+    };
+    const deadlineProvided = (deadline !== undefined);
+    const deadlineDate = parseDeadlineDateOnly(deadline);
+
+    const newTitle = String(title).trim();
+    // Samma parsning som kundformuläret (samarbete-svar.html) använder för att indexera svar mot frågor.
+    const parseTitleLines = (t) => String(t || '')
+      .split('\n')
+      .map(s => s.replace(/^\d+\.\s*/, '').trim())
+      .filter(Boolean);
+    const newLines = parseTitleLines(newTitle);
+
+    let existingAnswers = [];
+    const rawAns = (fields['Svar text'] || '').toString().trim();
+    if (rawAns.startsWith('[')) {
+      try { existingAnswers = JSON.parse(rawAns); } catch (_) { existingAnswers = []; }
+    }
+    const hadStructuredAnswers = Array.isArray(existingAnswers) && existingAnswers.length > 0;
+
+    // Bygg om svaren så att de följer med rätt fråga.
+    let newAnswers = null;
+    if (Array.isArray(answerMapping)) {
+      newAnswers = newLines.map((_, idx) => {
+        const orig = answerMapping[idx];
+        if (typeof orig === 'number' && orig >= 0 && existingAnswers[orig]) return existingAnswers[orig];
+        return { text: '', filename: null };
+      });
+    } else if (hadStructuredAnswers) {
+      // Ingen explicit mappning: bevara positionellt (bäst-möjligt), trimma/fyll till ny längd.
+      newAnswers = newLines.map((_, idx) => existingAnswers[idx] || { text: '', filename: null });
+    }
+
+    // Räkna ut status utifrån de (om-mappade) svaren och vilka punkter som kräver fil.
+    const computeUpdatedStatus = (answersArray) => {
+      const items = [];
+      const fileReq = [];
+      newTitle.split('\n').map(s => s.replace(/^\d+\.\s*/, '').trim()).filter(Boolean).forEach((line) => {
+        let r = /\[fil obligatorisk\]\s*$/i.test(line);
+        if (r) line = line.replace(/\s*\[fil obligatorisk\]\s*$/i, '').trim();
+        items.push(line);
+        fileReq.push(r);
+      });
+      const total = items.length;
+      if (!total) return null;
+      for (let i = 0; i < total; i++) {
+        const a = (answersArray && answersArray[i]) || {};
+        const hasText = a.text && String(a.text).trim().length > 0;
+        const hasFile = !!a.filename;
+        if (!hasText && !hasFile) return 'Väntar';
+        if (fileReq[i] && !hasFile) return 'Väntar';
+      }
+      return 'Besvarad';
+    };
+
+    const updateFields = { 'Titel': newTitle };
+    if (deadlineProvided) updateFields['Deadline'] = deadlineDate || null;
+    if (customerMessage != null) updateFields['Meddelande'] = String(customerMessage).trim().slice(0, 100000);
+
+    // Uppdatera bara svar/status om det fanns strukturerade svar eller om en mappning skickades.
+    // Annars lämnas äldre fri-text-svar och status orörda.
+    if (newAnswers) {
+      updateFields['Svar text'] = JSON.stringify(newAnswers);
+      const st = computeUpdatedStatus(newAnswers);
+      if (st) {
+        updateFields['Status'] = st;
+        updateFields['Besvarad'] = st === 'Besvarad'
+          ? (fields['Besvarad'] || new Date().toISOString().slice(0, 19).replace('T', ' '))
+          : null;
+      }
+    }
+
+    await axios.patch(
+      `https://api.airtable.com/v0/${airtableBaseId}/${tableId}/${requestId}`,
+      { fields: updateFields },
+      { headers: { Authorization: `Bearer ${airtableAccessToken}`, 'Content-Type': 'application/json' } }
+    );
+
+    // Meddela kunden att förfrågan uppdaterats (samma länk/token).
+    let emailSent = false;
+    let emailError = null;
+    const toEmail = (fields['Mottagare e-post'] || '').toString().trim();
+    const token = (fields['Token'] || '').toString().trim();
+    const wantNotify = notify !== false;
+    if (wantNotify && toEmail && toEmail.includes('@') && token) {
+      const reqHost = (req.get('host') || '').toString().trim();
+      const inferredBase = req.protocol + '://' + (reqHost || 'localhost:3001');
+      const defaultPublicBase = (reqHost.includes('localhost') || reqHost.includes('127.0.0.1')) ? inferredBase : 'https://www.app.clientflow.se';
+      const publicBaseUrl = (process.env.PUBLIC_BASE_URL || '').toString().trim() || defaultPublicBase;
+      const respondUrl = `${publicBaseUrl}/samarbete-svar.html?token=${encodeURIComponent(token)}`;
+
+      const senderName = (userData.name || req.user.email || '').toString().trim() || 'Vi';
+      const senderByra = (userData.byra || '').toString().trim() || null;
+      const logoRaw = userData.logo;
+      const senderLogoUrl = Array.isArray(logoRaw) && logoRaw.length > 0 && logoRaw[0].url
+        ? logoRaw[0].url
+        : (typeof logoRaw === 'string' && logoRaw.startsWith('http') ? logoRaw : null);
+
+      const result = await sendSamarbeteInviteEmail({
+        toEmail,
+        toName: (fields['Mottagare namn'] || '').toString().trim() || 'Kund',
+        senderName,
+        senderEmail: (req.user && req.user.email) ? String(req.user.email).trim() : undefined,
+        senderByra: senderByra || undefined,
+        senderLogoUrl: senderLogoUrl || undefined,
+        respondUrl,
+        title: newTitle,
+        customerMessage: (customerMessage != null && String(customerMessage).trim())
+          ? String(customerMessage).trim()
+          : ((fields['Meddelande'] || '').toString().trim() || undefined),
+        deadlineDate: deadlineProvided ? (deadlineDate || undefined) : (fields['Deadline'] || undefined),
+        isUpdate: true
+      });
+      emailSent = result.sent;
+      emailError = result.error || null;
+    }
+
+    res.json({
+      success: true,
+      emailSent,
+      emailError: emailError || undefined,
+      message: emailSent
+        ? `Förfrågan uppdaterad och ett mejl har skickats till ${toEmail}.`
+        : 'Förfrågan uppdaterad.'
+    });
+  } catch (error) {
+    const status = error.response?.status || 500;
+    const msg = error.response?.data?.error?.message || error.message;
+    console.error('PUT /api/samarbete/requests/:requestId/update:', msg);
+    res.status(status === 404 ? 404 : status).json({ error: msg });
   }
 });
 

--- a/public/js/kundkort.js
+++ b/public/js/kundkort.js
@@ -8200,6 +8200,15 @@ class CustomerCardManager {
         };
         const copyLinkBtn = (req) => `<button type="button" class="btn btn-secondary btn-sm" onclick="customerCardManager.copySamarbeteLink('${this.escapeDocHtml(req.id)}')" title="Kopiera länk till kundformulär"><i class="fas fa-link"></i> Kopiera länk</button>`;
         const resendEmailBtn = (req) => `<button type="button" class="btn btn-primary btn-sm" onclick="customerCardManager.resendSamarbeteEmail('${this.escapeDocHtml(req.id)}')" title="Skicka mejlet igen"><i class="fas fa-envelope"></i> Skicka mejl igen</button>`;
+        const updateRequestBtn = (req) => `<button type="button" class="btn btn-secondary btn-sm" onclick='customerCardManager.openEditSamarbeteModal(${JSON.stringify({
+            id: req.id,
+            title: req.title || '',
+            deadline: req.deadline || '',
+            recipientName: req.recipientName || '',
+            recipientEmail: req.recipientEmail || '',
+            customerMessage: req.customerMessage || '',
+            responseText: req.responseText || ''
+        }).replace(/'/g, "\\'")})' title="Lägg till/ändra frågor och meddela kunden"><i class="fas fa-pen"></i> Uppdatera</button>`;
         const uppdragBadge = (req) => {
             if (!(req && req.fromUppdrag)) return '';
             const typ = (req.uppdragTyp || '').toString().trim();
@@ -8266,6 +8275,7 @@ class CustomerCardManager {
                             ${titleLines.length > 0 ? `<div class="samarbete-block samarbete-block--questions">${questionsHtml}</div>` : ''}
                         </div>
                         <div class="samarbete-item-actions">
+                            ${updateRequestBtn(req)}
                             ${resendEmailBtn(req)}
                             <button type="button" class="btn btn-primary btn-sm" data-request-id="${this.escapeDocHtml(req.id)}" onclick="customerCardManager.archiveSamarbeteRequest('${this.escapeDocHtml(req.id)}')" title="Arkivera förfrågan"><i class="fas fa-archive"></i> Arkivera</button>
                             ${copyLinkBtn(req)}
@@ -8324,7 +8334,7 @@ class CustomerCardManager {
                             <div class="samarbete-block samarbete-block--questions">${responseHtml}</div>
                         </div>
                         <div class="samarbete-item-actions">
-                            ${req.closed ? '<span class="samarbete-closed-badge"><i class="fas fa-lock"></i> Stängd</span>' : ''}
+                            ${req.closed ? '<span class="samarbete-closed-badge"><i class="fas fa-lock"></i> Stängd</span>' : updateRequestBtn(req)}
                             <button type="button" class="btn btn-primary btn-sm" data-request-id="${this.escapeDocHtml(req.id)}" onclick="customerCardManager.archiveSamarbeteRequest('${this.escapeDocHtml(req.id)}')" title="Arkivera förfrågan"><i class="fas fa-archive"></i> Arkivera</button>
                         </div>
                     </div>
@@ -8930,6 +8940,176 @@ class CustomerCardManager {
         } catch (e) {
             this.showNotification(e.message || 'Kunde inte skicka utkast', 'error');
         }
+    }
+
+    openEditSamarbeteModal(reqJson) {
+        const req = (reqJson && typeof reqJson === 'object') ? reqJson : null;
+        if (!req || !req.id) return;
+        const existing = document.getElementById('samarbete-edit-modal');
+        if (existing) existing.remove();
+
+        // Parsa befintliga frågor på samma sätt som kundformuläret indexerar svar.
+        const titleFull = ((req.title || '') + '').trim();
+        const rawLines = titleFull
+            ? titleFull.split('\n').map(s => s.replace(/^\d+\.\s*/, '').trim()).filter(Boolean)
+            : [];
+        const parsed = rawLines.map((line) => {
+            const fileRequired = / \[fil obligatorisk\]/i.test(line) || /\[fil obligatorisk\]\s*$/i.test(line);
+            const text = line.replace(/\s*\[fil obligatorisk\]\s*$/i, '').trim();
+            return { text, fileRequired };
+        });
+
+        // Vilka ursprungliga punkter har redan ett svar (för att varna innan man tar bort dem).
+        let answeredFlags = [];
+        try {
+            const raw = (req.responseText || '').toString().trim();
+            if (raw.startsWith('[')) {
+                const arr = JSON.parse(raw);
+                if (Array.isArray(arr)) {
+                    answeredFlags = arr.map(a => !!(a && ((a.text && String(a.text).trim()) || (a.filename && String(a.filename).trim()))));
+                }
+            }
+        } catch (_) { answeredFlags = []; }
+
+        const rowHtml = (idx, text, fileRequired, origIndex, answered) => {
+            const checkedAttr = fileRequired ? ' checked' : '';
+            const checkedCls = fileRequired ? ' is-checked' : '';
+            const answeredBadge = answered
+                ? '<span class="badge badge-info" style="flex-shrink:0; background:#dcfce7; color:#166534; border:1px solid #bbf7d0; padding:2px 8px; border-radius:999px; font-weight:700; font-size:0.7rem;" title="Kunden har redan svarat på denna punkt"><i class="fas fa-check"></i> Besvarad</span>'
+                : '';
+            return `<div class="samarbete-item-row" data-orig-index="${origIndex === null ? '' : origIndex}">`
+                + `<input type="text" class="form-control samarbete-item-input" placeholder="t.ex. kontoutdrag 2025 eller en längre fråga" data-item="${idx}" value="${this.escapeDocHtml(text || '')}">`
+                + `<label class="samarbete-file-req-wrap${checkedCls}" title="Klicka för att kräva fil från kunden"><input type="checkbox" class="samarbete-file-required samarbete-file-required-input" data-item="${idx}"${checkedAttr}><span class="samarbete-file-req-icon"><i class="fas fa-file-upload"></i></span></label>`
+                + answeredBadge
+                + `<button type="button" class="btn btn-ghost btn-sm samarbete-item-remove" title="Ta bort" style="flex-shrink:0;"><i class="fas fa-times"></i></button>`
+                + `</div>`;
+        };
+
+        const initialRows = (parsed.length ? parsed : [{ text: '', fileRequired: false }])
+            .map((p, idx) => rowHtml(idx, p.text, p.fileRequired, parsed.length ? idx : null, !!answeredFlags[idx]))
+            .join('');
+
+        const wrap = document.createElement('div');
+        wrap.id = 'samarbete-edit-modal';
+        wrap.className = 'modal-overlay';
+        wrap.innerHTML = `
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3><i class="fas fa-pen"></i> Uppdatera förfrågan</h3>
+                    <button class="modal-close" onclick="document.getElementById('samarbete-edit-modal').remove()"><i class="fas fa-times"></i></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="samarbete-edit-id" value="${this.escapeDocHtml(req.id)}">
+                    <p class="samarbete-modal-hint">Lägg till, ändra eller ta bort frågor. Samma länk behålls och kundens redan inlämnade svar följer med. Ett mejl skickas till ${this.escapeDocHtml(req.recipientName || 'kunden')} om att förfrågan uppdaterats.</p>
+                    <div class="form-group">
+                        <label>Begärt underlag *</label>
+                        <div id="samarbete-edit-items-wrap">${initialRows}</div>
+                        <button type="button" class="btn btn-ghost btn-sm" id="samarbete-edit-add-item" style="margin-top:0.5rem;"><i class="fas fa-plus"></i> Lägg till fler frågor</button>
+                    </div>
+                    <div class="form-group">
+                        <label for="samarbete-edit-message">Meddelande till kunden <span style="color:#64748b; font-weight:400;">(visas i mejlet, valfritt)</span></label>
+                        <textarea id="samarbete-edit-message" class="form-control" rows="2" placeholder="t.ex. Jag har lagt till en fråga om reseräkningar">${this.escapeDocHtml(req.customerMessage || '')}</textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="samarbete-edit-deadline">Deadline <span style="color:#64748b; font-weight:400;">(valfri)</span></label>
+                        <input type="date" id="samarbete-edit-deadline" class="form-control" value="${this.escapeDocHtml((req.deadline || '').toString().slice(0, 10))}" />
+                    </div>
+                    <div class="form-actions">
+                        <button type="button" class="btn btn-ghost" onclick="document.getElementById('samarbete-edit-modal').remove()">Avbryt</button>
+                        <button type="button" class="btn btn-primary" id="samarbete-edit-submit" onclick="customerCardManager.submitEditSamarbete('${this.escapeDocHtml(req.id)}')">
+                            <i class="fas fa-paper-plane"></i> Uppdatera & meddela kund
+                        </button>
+                    </div>
+                </div>
+            </div>`;
+        document.body.appendChild(wrap);
+
+        const wrapEl = document.getElementById('samarbete-edit-items-wrap');
+        const addBtn = document.getElementById('samarbete-edit-add-item');
+        const self = this;
+        if (addBtn && wrapEl) {
+            addBtn.addEventListener('click', () => {
+                const n = wrapEl.querySelectorAll('.samarbete-item-row').length;
+                const tmp = document.createElement('div');
+                tmp.innerHTML = self.openEditSamarbeteRowHtml(n);
+                const row = tmp.firstElementChild;
+                wrapEl.appendChild(row);
+            });
+            wrapEl.addEventListener('click', (e) => {
+                const rm = e.target.closest('.samarbete-item-remove');
+                if (rm && rm.closest('.samarbete-item-row')) rm.closest('.samarbete-item-row').remove();
+            });
+            wrapEl.addEventListener('change', (e) => {
+                const chk = e.target.closest('.samarbete-file-required-input');
+                if (chk) {
+                    const w = chk.closest('.samarbete-file-req-wrap');
+                    if (w) {
+                        w.classList.toggle('is-checked', chk.checked);
+                        w.title = chk.checked ? 'Fil krävs – klicka för att ta bort kravet' : 'Klicka för att kräva fil från kunden';
+                    }
+                }
+            });
+        }
+    }
+
+    openEditSamarbeteRowHtml(n) {
+        return `<div class="samarbete-item-row" data-orig-index=""><input type="text" class="form-control samarbete-item-input" placeholder="t.ex. ytterligare underlag eller fråga" data-item="${n}"><label class="samarbete-file-req-wrap" title="Klicka för att kräva fil från kunden"><input type="checkbox" class="samarbete-file-required samarbete-file-required-input" data-item="${n}"><span class="samarbete-file-req-icon"><i class="fas fa-file-upload"></i></span></label><button type="button" class="btn btn-ghost btn-sm samarbete-item-remove" title="Ta bort" style="flex-shrink:0;"><i class="fas fa-times"></i></button></div>`;
+    }
+
+    async submitEditSamarbete(requestId) {
+        const rows = document.querySelectorAll('#samarbete-edit-items-wrap .samarbete-item-row');
+        const btn = document.getElementById('samarbete-edit-submit');
+        const items = [];
+        rows.forEach((row) => {
+            const inp = row.querySelector('.samarbete-item-input');
+            const chk = row.querySelector('.samarbete-file-required');
+            const text = (inp && inp.value) ? inp.value.trim() : '';
+            if (!text) return;
+            const origRaw = row.getAttribute('data-orig-index');
+            const origIndex = (origRaw === null || origRaw === '') ? null : parseInt(origRaw, 10);
+            items.push({ text, fileRequired: !!(chk && chk.checked), origIndex: Number.isNaN(origIndex) ? null : origIndex });
+        });
+        if (items.length === 0) {
+            this.showNotification('Lägg till minst en fråga eller underlagsbegäran.', 'error');
+            return;
+        }
+        const title = items.length === 1
+            ? (items[0].text + (items[0].fileRequired ? ' [fil obligatorisk]' : ''))
+            : items.map((it, i) => `${i + 1}. ${it.text}${it.fileRequired ? ' [fil obligatorisk]' : ''}`).join('\n');
+        // Svaren indexeras mot frågorna i samma ordning, så answerMapping följer items-ordningen.
+        const answerMapping = items.map(it => (it.origIndex === null ? null : it.origIndex));
+        const messageEl = document.getElementById('samarbete-edit-message');
+        const customerMessage = (messageEl && messageEl.value) ? messageEl.value.trim() : '';
+        const deadlineEl = document.getElementById('samarbete-edit-deadline');
+        const deadline = (deadlineEl && deadlineEl.value) ? deadlineEl.value : '';
+
+        if (btn) { btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Uppdaterar...'; }
+        try {
+            const baseUrl = window.apiConfig?.baseUrl || 'http://localhost:3001';
+            const payload = {
+                title,
+                deadline,
+                customerMessage: customerMessage || undefined,
+                answerMapping,
+                notify: true
+            };
+            const res = await fetch(`${baseUrl}/api/samarbete/requests/${encodeURIComponent(requestId)}/update`, {
+                method: 'PUT',
+                ...getAuthOptsKundkort(),
+                headers: { 'Content-Type': 'application/json', ...(getAuthOptsKundkort().headers || {}) },
+                body: JSON.stringify(payload)
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) throw new Error(data.error || 'Kunde inte uppdatera förfrågan');
+            const modal = document.getElementById('samarbete-edit-modal');
+            if (modal) modal.remove();
+            this.showNotification(data.message || 'Förfrågan uppdaterad.', 'success');
+            if (data.emailError) this.showNotification('Mejlet kunde inte skickas: ' + data.emailError, 'error');
+            this.loadSamarbete();
+        } catch (e) {
+            this.showNotification(e.message || 'Kunde inte uppdatera förfrågan', 'error');
+        }
+        if (btn) { btn.disabled = false; btn.innerHTML = '<i class="fas fa-paper-plane"></i> Uppdatera & meddela kund'; }
     }
 
     showStatusValModal() {

--- a/public/kundkort.html
+++ b/public/kundkort.html
@@ -182,6 +182,6 @@
     <script src="app.js?v=2.1"></script>
     <!-- Bumpad version för att säkerställa att senaste kundkort.js laddas -->
     <script src="js/moms-period.js?v=1.0"></script>
-    <script src="js/kundkort.js?v=14.7"></script>
+    <script src="js/kundkort.js?v=14.8"></script>
 </body>
 </html>


### PR DESCRIPTION
Gör det möjligt att uppdatera en redan skickad underlagsförfrågan (t.ex. lägga till en fråga) och meddelar kunden via mejl.

**Backend (`index.js`)**
- Ny endpoint `PUT /api/samarbete/requests/:requestId/update` (samma byrå-behörighetskontroll som övriga samarbete-endpoints). Uppdaterar frågorna (`Titel`), `Deadline` och valfritt `Meddelande`.
- Utökar `sendSamarbeteInviteEmail` med en `isUpdate`-variant (återanvänder samma nodemailer/SMTP, branding, logga och mall). Mejlar kunden: ämne *"Din underlagsförfrågan har uppdaterats – från {avsändare}"*.

**Frontend (`public/js/kundkort.js`, `public/kundkort.html`)**
- Ny **"Uppdatera"**-knapp på väntande och besvarade förfrågningar som öppnar en redigeringsmodal (speglar skapa-förfrågan-UI:t). Cache-bump `v=14.7 → 14.8`.

**Token/länk och svar bevaras:** endpointen rör aldrig `Token`, så kundens länk fortsätter fungera. Frontend skickar en `answerMapping` och backend bygger om svars-JSON i ny ordning så att redan inskickade svar/filer hålls i linje även när frågor läggs till, tas bort eller flyttas. Status räknas om (en ny obesvarad fråga gör att "Besvarad" → "Väntar").

**Beslut:** stängda/avslutade förfrågningar är inte redigerbara (endpoint returnerar 409, knappen döljs).

Fristående PR, inga beroenden.
