### PR TITLE
Fix: Uppdrag-fliken kraschar pga TDZ-fel (ptlUnderlagRaw)

### DIFF
--- a/public/js/kundkort.js
+++ b/public/js/kundkort.js
@@ -2935,6 +2935,9 @@ class CustomerCardManager {
                             <div class="uppdrag-riskbox-title">Inga åtgärder hittades i kundens riskbedömning</div>
                         </div>`;
 
+        const ptlUnderlagRaw = (f['PTL Underlag'] || '').toString().trim();
+        const ptlUnderlagJson = this._esc(ptlUnderlagRaw || '[]');
+
         const ptlSectionHtml = hasRiskAtgarder ? `
                         <div class="uppdrag-block">
                             <label class="uppdrag-label"><i class="fas fa-paperclip"></i> Underlag till PTL-åtgärd (valfritt)</label>
@@ -2942,7 +2945,7 @@ class CustomerCardManager {
                             <div class="uppdrag-actions" style="margin-top:0.5rem;">
                                 <button type="button" class="btn btn-secondary btn-sm" data-action="upload-ptl"><i class="fas fa-upload"></i> Ladda upp underlag</button>
                             </div>
-                            <textarea class="kunduppgifter-input" rows="2" data-field="PTL Underlag" style="display:none;">${this._esc(ptlUnderlagRaw || '[]')}</textarea>
+                            <textarea class="kunduppgifter-input" rows="2" data-field="PTL Underlag" style="display:none;">${ptlUnderlagJson}</textarea>
                             <div class="uppdrag-ptl-files" data-ptl-files></div>
                             <div class="uppdrag-muted" style="margin-top:0.35rem;">Filerna sparas på fliken Dokumentation (kategori: riskbedömning).</div>
                         </div>
@@ -2956,8 +2959,6 @@ class CustomerCardManager {
         ` : '';
 
         const riskValdaJson = this._esc(JSON.stringify(riskValda || []));
-        const ptlUnderlagRaw = (f['PTL Underlag'] || '').toString().trim();
-        const ptlUnderlagJson = this._esc(ptlUnderlagRaw || '[]');
 
         const isDone = this._isUppdragDoneForPeriod(f);
         const doneBtnClass = isDone ? 'uppdrag-done-btn is-done' : 'uppdrag-done-btn';

--- a/public/kundkort.html
+++ b/public/kundkort.html
@@ -182,6 +182,6 @@
     <script src="app.js?v=2.1"></script>
     <!-- Bumpad version för att säkerställa att senaste kundkort.js laddas -->
     <script src="js/moms-period.js?v=1.0"></script>
-    <script src="js/kundkort.js?v=14.7"></script>
+    <script src="js/kundkort.js?v=14.8"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

Fliken **Uppdrag** på kundkortet kraschade med körtidsfelet:

`ReferenceError: Cannot access 'ptlUnderlagRaw' before initialization`

i `CustomerCardManager._renderUppdragKort` (`public/js/kundkort.js`). I gränssnittet visades "Kunde inte ladda uppdrag."

## Orsak

Variabeln `ptlUnderlagRaw` användes i `textarea` för "PTL Underlag" innan den deklarerades med `const` längre ner i metoden. Eftersom `const` är block-scoped och hamnar i den temporala dödzonen (TDZ) kastas ett fel när den används före deklarationen.

## Åtgärd

- Flyttade `const ptlUnderlagRaw` och `const ptlUnderlagJson` så att de deklareras före första användningen (efter att `f` är definierat).
- Återanvänder `${ptlUnderlagJson}` i `textarea` istället för att räkna om `this._esc(ptlUnderlagRaw || '[]')` — identiskt beteende.
- Tog bort den duplicerade deklarationen längre ner.
- Bumpade cache-busting-versionen i `public/kundkort.html` (`v=14.7` → `v=14.8`) så att fixen distribueras.

## Verifiering

- `node -c public/js/kundkort.js` — inga syntaxfel.
- Deklarationen föregår nu alla användningar och inga duplicerade `const`-rader finns kvar.

> Obs: Versionsraden i `public/kundkort.html` bumpas även av en separat öppen PR (#5). En trivial merge-konflikt på just den raden är förväntad och acceptabel.
