### PR TITLE
Lägg till källvisning (kalla) på hot-kort i Redigera tjänst

### DIFF
--- a/index.js
+++ b/index.js
@@ -14993,7 +14993,7 @@ Analysera hur just denna tjänst kan utnyttjas för penningtvätt (PT) eller ter
 
 KRAV PÅ INNEHÅLLET:
 - "tjanstebeskrivning": 2–4 meningar som beskriver vad tjänsten innebär i praktiken och varför den ger byrån insyn/exponering. Saklig svenska, inga UI-termer.
-- "hot": 2–4 konkreta hot. Varje hot har "typ" som är antingen "PT" (penningtvätt) eller "TF" (terrorfinansiering), en kort "titel" (3–6 ord) och en "beskrivning" (1–2 meningar om tillvägagångssättet).
+- "hot": 2–4 konkreta hot. Varje hot har "typ" som är antingen "PT" (penningtvätt) eller "TF" (terrorfinansiering), en kort "titel" (3–6 ord), en "beskrivning" (1–2 meningar om tillvägagångssättet) och en "kalla" (relevant källhänvisning, t.ex. "Finanspolisen", "FATF" eller en URL som börjar med http).
 - "sarbarheter": 2–4 sårbarheter/riskfaktorer. Varje har "kategori" som är EXAKT en av: "Kunder", "Distribution", "Geografi", "Verksamhet". "titel" (2–5 ord) och "beskrivning" (1 mening).
 - "atgarder": 3–5 tjänstespecifika åtgärder. Varje har en "titel" (2–6 ord) och en "beskrivning" som anger VAD som kontrolleras och VAD som dokumenteras. Proportionerligt för en redovisningsbyrå – inte "polisarbete" eller löpande realtidsövervakning.
 - "riskniva": EXAKT en av "Låg", "Medel" eller "Hög" – byråns sammanvägda inneboende risknivå för tjänsten.
@@ -15004,7 +15004,7 @@ Svara EXAKT i detta JSON-format (inget annat, ingen text utanför JSON):
 {
   "tjanstebeskrivning": "…",
   "riskniva": "Låg" | "Medel" | "Hög",
-  "hot": [ { "typ": "PT" | "TF", "titel": "…", "beskrivning": "…" } ],
+  "hot": [ { "typ": "PT" | "TF", "titel": "…", "beskrivning": "…", "kalla": "…" } ],
   "sarbarheter": [ { "kategori": "Kunder" | "Distribution" | "Geografi" | "Verksamhet", "titel": "…", "beskrivning": "…" } ],
   "atgarder": [ { "titel": "…", "beskrivning": "…" } ]
 }`;
@@ -15078,7 +15078,7 @@ Svara EXAKT i detta JSON-format (inget annat, ingen text utanför JSON):
     if (!result || typeof result !== 'object') throw new Error('Kunde inte tolka AI-svar.');
 
     const hot = Array.isArray(result.hot) ? result.hot
-      .map(h => ({ typ: normHotTyp(h?.typ), titel: cleanStr(h?.titel), beskrivning: cleanStr(h?.beskrivning) }))
+      .map(h => ({ typ: normHotTyp(h?.typ), titel: cleanStr(h?.titel), beskrivning: cleanStr(h?.beskrivning), kalla: cleanStr(h?.kalla ?? h?.källa ?? h?.source) }))
       .filter(h => h.titel || h.beskrivning) : [];
     const sarbarheter = Array.isArray(result.sarbarheter) ? result.sarbarheter
       .map(s => ({ kategori: normKategori(s?.kategori), titel: cleanStr(s?.titel), beskrivning: cleanStr(s?.beskrivning) }))

--- a/public/js/riskbedomning-byra.v3.js
+++ b/public/js/riskbedomning-byra.v3.js
@@ -538,6 +538,7 @@ class RiskAssessmentManager {
         const typ = ((data.typ ?? data.type) || '').toString().toUpperCase() === 'TF' ? 'TF' : 'PT';
         const titel = data.titel ?? data.title ?? '';
         const beskrivning = data.beskrivning ?? data.description ?? '';
+        const kalla = data.kalla ?? data.källa ?? data.source ?? '';
         const row = document.createElement('div');
         row.className = 'dyn-row dyn-row-hot';
         row.innerHTML = `
@@ -548,11 +549,35 @@ class RiskAssessmentManager {
             <div class="dyn-fields">
                 <input type="text" class="dyn-titel" placeholder="Hotets titel" value="${this.esc(titel)}">
                 <textarea class="dyn-besk" rows="2" placeholder="Tillvägagångssätt">${this.esc(beskrivning)}</textarea>
+                <div class="dyn-kalla-row">
+                    <i class="fas fa-link dyn-kalla-icon" aria-hidden="true"></i>
+                    <input type="text" class="dyn-kalla" placeholder="Källa, t.ex. Finanspolisen eller FATF" value="${this.esc(kalla)}">
+                    <a class="dyn-kalla-link" target="_blank" rel="noopener" style="display:none;">Öppna källa ↗</a>
+                </div>
             </div>
             <button type="button" class="dyn-remove" title="Ta bort"><i class="fas fa-times"></i></button>
         `;
         row.querySelector('.dyn-remove').addEventListener('click', () => row.remove());
+        const kallaInput = row.querySelector('.dyn-kalla');
+        const kallaLink = row.querySelector('.dyn-kalla-link');
+        const syncKallaLink = () => {
+            const val = kallaInput.value.trim();
+            if (this.isKallaUrl(val)) {
+                kallaLink.href = val;
+                kallaLink.style.display = '';
+            } else {
+                kallaLink.removeAttribute('href');
+                kallaLink.style.display = 'none';
+            }
+        };
+        kallaInput.addEventListener('input', syncKallaLink);
+        syncKallaLink();
         list.appendChild(row);
+    }
+
+    // Källa räknas som länk endast om värdet börjar med http(s).
+    isKallaUrl(value) {
+        return /^https?:\/\//i.test((value || '').toString().trim());
     }
 
     addSarbarhetRow(data = {}) {
@@ -599,8 +624,9 @@ class RiskAssessmentManager {
         return [...document.querySelectorAll('#hot-list .dyn-row')].map(row => ({
             typ: row.querySelector('.dyn-typ')?.value || 'PT',
             titel: row.querySelector('.dyn-titel')?.value.trim() || '',
-            beskrivning: row.querySelector('.dyn-besk')?.value.trim() || ''
-        })).filter(h => h.titel || h.beskrivning);
+            beskrivning: row.querySelector('.dyn-besk')?.value.trim() || '',
+            kalla: row.querySelector('.dyn-kalla')?.value.trim() || ''
+        })).filter(h => h.titel || h.beskrivning || h.kalla);
     }
 
     collectSarbarhet() {

--- a/public/styles.css
+++ b/public/styles.css
@@ -11339,6 +11339,39 @@ textarea.kunduppgifter-input.uppdrag-run-note[readonly] {
     font-family: inherit;
 }
 .dyn-row .dyn-besk { resize: vertical; }
+/* Diskret källrad längst ned i hot-kortet (källhänvisning + ev. länk) */
+.dyn-row .dyn-kalla-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    border-top: 0.5px solid var(--line);
+    padding-top: 6px;
+    margin-top: 2px;
+}
+.dyn-row .dyn-kalla-icon {
+    font-size: 14px;
+    color: var(--ink-3);
+    flex-shrink: 0;
+}
+.dyn-row .dyn-kalla {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: transparent;
+    font-size: 12px;
+    color: var(--text);
+    font-family: inherit;
+    padding: 2px 0;
+}
+.dyn-row .dyn-kalla:focus { outline: none; }
+.dyn-row .dyn-kalla-link {
+    flex-shrink: 0;
+    font-size: 11px;
+    white-space: nowrap;
+    color: var(--accent);
+    text-decoration: none;
+}
+.dyn-row .dyn-kalla-link:hover { text-decoration: underline; }
 .dyn-remove {
     flex-shrink: 0;
     width: 28px;


### PR DESCRIPTION
## Sammanfattning
Lägger till ett diskret "källa"-fält (`kalla`) på varje hot-kort i "Redigera tjänst"-dialogen för byråns tjänster.

## Ändringar
- `public/js/riskbedomning-byra.v3.js`: `addHotRow()` renderar en källrad (separator + `fa-link`-ikon + transparent textinput) under beskrivningen, med en "Öppna källa ↗"-länk som visas live endast när värdet är en URL (`http`). `collectHot()` serialiserar nu `kalla`.
- `public/styles.css`: nya klasser `.dyn-kalla-row`, `.dyn-kalla-icon`, `.dyn-kalla`, `.dyn-kalla-link` med projektets designtokens (`--line`, `--text`, `--ink-3`, `--accent`).
- `index.js` (`/api/ai-byra-tjanst`): prompten ber om `kalla` per hot, JSON-schemat utökat, och svaret normaliseras med `kalla`.

Ingen backend-persistensändring behövdes — hela `Hot`-JSON:en (inkl. `kalla`) round-trippar redan via POST/PUT/GET.

## Dataflöde
AI-svar → formulärfält → `collectHot` → `Hot`-JSON → Airtable → GET → återfylls i dialogen.

## Test
- [x] `node --check` på `riskbedomning-byra.v3.js` och `index.js`.
- [ ] Generera med AI → källrad ifylld; URL ger "Öppna källa ↗", namn ger ingen länk.
- [ ] Spara och återöppna → källan kvarstår.
