### PR TITLE
Recolor till petrol-designsystem (STEG 1-5)

### DIFF
--- a/public/clientflow-design-system.md
+++ b/public/clientflow-design-system.md
@@ -1,0 +1,179 @@
+# ClientFlow — Designsystem
+
+Referensdokument för design. Läs detta innan du ändrar UI. All färg och
+typografi kommer från `clientflow-tokens.css` — hårdkoda aldrig hex-värden
+i komponenter, använd alltid `var(--cf-*)`.
+
+---
+
+## 1. Grundprinciper
+
+**En accentfärg, ägd.** ClientFlow använder petrol (`--cf-accent`, `#13505c`)
+för allt interaktivt: aktiv navigation, primärknappar, länkar, fokus, valda
+element. Den ska inte ersättas av generisk indigo/lila. Den är medvetet
+blå-lutande så den aldrig krockar med grön (klar) eller röd (problem).
+
+**Två temperaturer, ett system.** Interna byrå-vyer är *svala och täta* — en
+cockpit man sitter i hela dagar. Kundvända ytor är *varma och lugna* — sällan-
+användare som ska känna förtroende. Samma brand- och statusfärger, olika
+neutralpalett. Varmt fås genom att lägga klassen `cf-warm` på en wrapper.
+
+**Återhållsamhet.** Det här är ett compliance-verktyg, inte en leksak. Diskreta
+skuggor, hårfina linjer, ingen färg utan funktion. Elegansen ligger i mellanrum
+och hierarki, inte i effekter.
+
+---
+
+## 2. Färgsemantik — den viktigaste regeln
+
+Färg betyder något. Använd aldrig en statusfärg dekorativt.
+
+| Färg | Token | Betyder | Använd INTE för |
+|------|-------|---------|-----------------|
+| Röd | `--cf-danger` | Verkligt problem, hög risk, fel | "Inte gjort än" |
+| Amber | `--cf-warn` | Ofullständig, behöver åtgärd, todo | Allmän info |
+| Grön | `--cf-ok` | Klar, godkänd, klarmarkerad | Dekoration / accent |
+| Petrol | `--cf-accent` | Varumärke, interaktion, navigation | Status |
+
+**Konkreta fall som ska rättas i nuvarande system:**
+- Flikarna "KYC-formulär" / "Uppdragsavtal" med röd ❗ som bara betyder *ej
+  ifyllt* → ska vara **amber**, inte röd. Spara rött för faktiska problem.
+- Felmeddelandet "kunde inte sparas — kontakta support" var stylat som lugn
+  lila info → ett fel ska läsa som **varning/röd**, annars lär sig användaren
+  ignorera färgerna.
+- Åtgärdslistor får inte vara en heltäckande grön vägg. Vit rad + liten grön
+  bock räcker; då behåller grönt sin signal.
+
+---
+
+## 3. Typografi
+
+- **UI överallt:** Schibsted Grotesk (`--cf-font-ui`). En skandinavisk grotesk
+  som knyter an till den feta ClientFlow-loggan.
+- **Sidtitlar** (DASHBOARD, KUNDKORT, RISKBEDÖMNINGAR): versaler, vikt 800,
+  letter-spacing `--cf-title-spacing`. Detta plockar upp loggans självförtroende.
+- **Serif (Fraunces)** används BARA för stora display-rubriker på varma kund-
+  ytor (t.ex. "Lämna underlag"). Aldrig i den interna appen — serif över
+  hundratals datafält blir tröttsamt och långsamt att skanna.
+
+Installera typsnitten (Vite):
+```
+npm i @fontsource/schibsted-grotesk @fontsource/fraunces
+```
+```ts
+// main.tsx
+import '@fontsource/schibsted-grotesk/400.css';
+import '@fontsource/schibsted-grotesk/500.css';
+import '@fontsource/schibsted-grotesk/600.css';
+import '@fontsource/schibsted-grotesk/700.css';
+import '@fontsource/schibsted-grotesk/800.css';
+import '@fontsource/fraunces/500.css';   // endast om varma ytor används
+import './clientflow-tokens.css';
+```
+
+---
+
+## 4. Komponentmönster
+
+Kärnmönstren, uttryckta i ren CSS med tokens. Anpassa till ert sätt att
+styla (CSS-moduler, Tailwind `@apply`, eller styled). Logiken är densamma.
+
+### Primärknapp
+```css
+.cf-btn-primary {
+  font-family: var(--cf-font-ui);
+  font-size: 13.5px; font-weight: var(--cf-weight-semibold);
+  color: #fff; background: var(--cf-accent);
+  border: none; border-radius: var(--cf-radius-sm);
+  padding: 9px 16px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 7px;
+  box-shadow: 0 1px 2px rgba(13,58,67,.2);
+  transition: .15s;
+}
+.cf-btn-primary:hover { background: var(--cf-accent-deep); }
+```
+
+### Sekundär / ikonknapp
+```css
+.cf-btn {
+  font: inherit; font-weight: 600; font-size: 13px;
+  color: var(--cf-ink-2); background: var(--cf-panel);
+  border: 1px solid var(--cf-line-2); border-radius: var(--cf-radius-sm);
+  padding: 8px 13px; cursor: pointer; transition: .15s;
+}
+.cf-btn:hover { background: var(--cf-panel-2); border-color: var(--cf-ink-3); }
+```
+
+### Kort / panel
+```css
+.cf-card {
+  background: var(--cf-panel);
+  border: 1px solid var(--cf-line);
+  border-radius: var(--cf-radius);
+  box-shadow: var(--cf-shadow-sm);
+}
+```
+
+### Navigation — aktiv state (petrol, ej lila)
+```css
+.cf-nav-item { color: var(--cf-ink-2); border-radius: 9px; padding: 9px 12px; }
+.cf-nav-item:hover { background: #f3f4f6; color: var(--cf-ink); }
+.cf-nav-item.active {
+  background: var(--cf-accent-tint);
+  color: var(--cf-accent-deep);
+  font-weight: 600;
+}
+/* liten petrol-stapel i vänsterkanten på aktiv rad */
+.cf-nav-item.active::before {
+  content:""; position:absolute; left:-12px; top:7px; bottom:7px;
+  width:3px; border-radius:0 3px 3px 0; background: var(--cf-accent);
+}
+```
+
+### Statusbadge / risknivå
+```css
+.cf-badge       { font-size:11px; font-weight:700; padding:3px 9px; border-radius:5px; text-transform:uppercase; letter-spacing:.05em; }
+.cf-badge--hog  { background: var(--cf-danger-tint); color: var(--cf-danger); }
+.cf-badge--medel{ background: var(--cf-warn-tint);   color: var(--cf-warn); }
+.cf-badge--klar { background: var(--cf-ok-tint);     color: var(--cf-ok); }
+```
+
+### Räknar-pill i listor (dra ögat dit det finns att göra)
+```css
+.cf-count       { font-size:11.5px; font-weight:700; padding:2px 8px; border-radius:20px;
+                  background: var(--cf-accent-tint); color: var(--cf-accent-deep); }
+.cf-count--warn { background: var(--cf-warn-tint); color: var(--cf-warn); }  /* öppna ärenden */
+.cf-count--zero { background: var(--cf-ok-tint);   color: var(--cf-ok); }    /* allt klart */
+```
+
+### Checkbox (petrol vid ikryssad)
+```css
+.cf-check input:checked + .box { background: var(--cf-accent); border-color: var(--cf-accent); }
+.cf-check .box { width:17px; height:17px; border:1.5px solid var(--cf-line-2);
+                 border-radius:5px; background:#fff; }
+```
+
+### Input + fokus
+```css
+.cf-input { border:1px solid var(--cf-line-2); border-radius:9px; padding:11px 14px;
+            font:inherit; background:#fff; }
+.cf-input:focus { outline:none; border-color: var(--cf-accent); box-shadow: var(--cf-focus); }
+```
+
+---
+
+## 5. Att göra / inte göra
+
+**Gör:**
+- Referera tokens (`var(--cf-*)`) — aldrig råa hex-värden i komponenter.
+- Ge listrader en räknare/badge när det finns något att åtgärda.
+- Ge varje menyrad en ikon (snabbare att skanna).
+- Håll interna vyer svala och täta; varma bara på kundytor via `.cf-warm`.
+
+**Gör inte:**
+- Använd inte generisk indigo/lila som accent.
+- Använd inte röd för "ej gjort" — det är amber.
+- Måla inte hela listor gröna — grönt ska betyda "klar".
+- Använd inte serif i den interna appen.
+- Byt inte ut ClientFlow-loggan (den feta svarta Client/Flow-stacken är
+  varumärkets bästa tillgång — den behålls).

--- a/public/clientflow-root.css
+++ b/public/clientflow-root.css
@@ -1,0 +1,111 @@
+/* =====================================================================
+   ClientFlow – NY färgskala (petrol, sval, ägd)
+   ---------------------------------------------------------------------
+   DROP-IN: ersätt ditt nuvarande :root-block (rad ~4–31 i styles.css)
+   med detta. Variabel-NAMNEN är oförändrade, så inget i appen går sönder
+   – bara värdena byts, vilket omfärgar allt som redan använder var(--...).
+
+   Efter detta: se de 4 manuella stegen längst ned (bakgrund, typsnitt,
+   gradient-knappar och hårdkodade hex). De ligger utanför :root.
+   ===================================================================== */
+:root {
+  --container-max: 1500px;
+
+  /* --- Text --- */
+  --text:        #5a626d;   /* var #374151  – sekundär/brödtext, lite svalare */
+  --title-text:  #15181d;   /* var #1e293b  – rubriker, högre kontrast */
+
+  /* --- Knappar: SOLID petrol istället för lila gradient --- */
+  --btn-bg:        #13505c;          /* var linear-gradient(...#667eea...#764ba2) */
+  --btn-bg-hover:  #0d3a43;          /* var #5a67d8 */
+  --btn-text:      #ffffff;
+  --btn-radius:    10px;             /* var 12px – aning stramare */
+
+  /* --- Typsnitt: Schibsted Grotesk (skandinavisk grotesk) --- */
+  --title-font: "Schibsted Grotesk", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  --body-font:  "Schibsted Grotesk", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  --title-weight: 700;               /* var 600 */
+  --body-weight:  400;
+
+  /* --- Accent (petrol – blå-lutande så den ej krockar med grön/röd) --- */
+  --accent:        #13505c;          /* var #667eea */
+  --accent-dark:   #0d3a43;          /* var #764ba2 */
+  --accent-light:  #bcd6da;          /* var #a5b4fc – ljus petrol */
+  --muted:         #e3eef0;          /* var #eef2ff – accent-tint (aktiva ytor) */
+  --muted-alt:     #d3e3e6;          /* var #e0e7ff */
+  --border:        #dcdfe5;          /* var #c7d2fe – neutral sval kant (ej lila) */
+
+  --radius:     12px;
+  --radius-xl:  16px;
+
+  --sidebar-bg: #ffffff;
+  --card-bg:    #ffffff;
+  --card-shadow: 0 1px 2px rgba(21,24,29,.04), 0 8px 28px rgba(21,24,29,.06); /* var lila skugga */
+
+  /* --- Status: ENBART för sin betydelse --- */
+  --success: #1f8a4c;   /* klar/godkänd */
+  --warning: #b07414;   /* ofullständig / behöver åtgärd  ← använd denna för "ej gjort", inte error */
+  --error:   #c23b2e;   /* verkligt fel / hög risk */
+
+  /* --- NYA hjälpvariabler (för uppstädning av hårdkodade hex) --- */
+  --app-bg:      #f5f6f8;   /* sval sidbakgrund (ersätter lavendel #f5f3ff) */
+  --panel-2:     #fafbfc;   /* nästlad yta */
+  --ink-3:       #8b929d;   /* ikoner i vila, tertiär text */
+  --label:       #9aa1ab;   /* versala fältetiketter / gruppnamn */
+  --line:        #e8eaee;   /* hårfin linje */
+  --success-tint:#e7f3ec;
+  --warning-tint:#f8eed7;
+  --error-tint:  #fbe9e7;
+  --accent-tint: #e3eef0;   /* = --muted, alias för tydlighet */
+
+  /* --- VARM kundyta: sätt klassen .cf-warm på formulärets wrapper --- */
+}
+
+/* Varm temperatur för kundvända ytor (underlags-formuläret).
+   Återanvänder accent/status ovan, byter bara neutraler + display-typsnitt. */
+.cf-warm {
+  --app-bg:     #f4efe6;
+  --card-bg:    #fffdf8;
+  --panel-2:    #fbf8f1;
+  --text:       #6b6456;
+  --title-text: #1c1b17;
+  --border:     #e4ddce;
+  --line:       #e4ddce;
+  --title-font: "Fraunces", Georgia, serif;   /* serif endast på stora varma rubriker */
+}
+
+
+/* =====================================================================
+   4 MANUELLA STEG (utanför :root)
+   ===================================================================== */
+
+/* STEG A — Sval bakgrund istället för lavendel.
+   I styles.css rad ~33 & ~35 står background: #f5f3ff hårdkodat. Byt till: */
+/*
+html { scroll-behavior: smooth; background: var(--app-bg); }
+body { ... background: var(--app-bg); ... }
+*/
+
+/* STEG B — Ladda Schibsted Grotesk (+ Fraunces om varm yta används).
+   Lägg i <head> där Inter laddas idag, ELLER överst i CSS:
+*/
+/*
+@import url('https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,500&display=swap');
+*/
+/* (Vite-alternativ: npm i @fontsource/schibsted-grotesk och importera vikterna i entry.) */
+
+/* STEG C — AI-element använder hårdkodad lila gradient. Byt till petrol.
+   Gäller .btn-ai (rad ~11269) och .ai-suggest-bar (rad ~11244): */
+/*
+.btn-ai        { background: var(--accent); }            // var linear-gradient(135deg,#667eea,#764ba2)
+.btn-ai:hover  { background: var(--accent-dark); transform: translateY(-1px); }
+.ai-suggest-bar{ background: var(--accent-tint); border-color: var(--accent-light); }
+.btn-add-row   { border-color: var(--accent-light); background: var(--accent-tint); color: var(--accent); }
+*/
+
+/* STEG D — Åtgärdslistan ska inte vara en grön vägg (rad ~11183).
+   Gör raderna neutrala med en liten grön bock istället: */
+/*
+.action-item { background: var(--card-bg); border: 1px solid var(--line); }
+.action-icon { color: var(--success); }
+*/

--- a/public/js/kundkort.js
+++ b/public/js/kundkort.js
@@ -673,7 +673,7 @@ class CustomerCardManager {
                 'Företagsinformation klarmarkerad');
         } else {
             this._setTabStatus('foretagsinformation',
-                '<i class="fas fa-exclamation-circle tab-status--warn" aria-hidden="true"></i>',
+                '<i class="fas fa-exclamation-circle tab-status--incomplete" aria-hidden="true"></i>',
                 'Företagsinformation ej klarmarkerad');
         }
 
@@ -683,7 +683,7 @@ class CustomerCardManager {
                 'Riskbedömning klarmarkerad');
         } else {
             this._setTabStatus('ovrigkyc',
-                '<i class="fas fa-exclamation-circle tab-status--warn" aria-hidden="true"></i>',
+                '<i class="fas fa-exclamation-circle tab-status--incomplete" aria-hidden="true"></i>',
                 'Riskbedömning ej klarmarkerad');
         }
 
@@ -693,7 +693,7 @@ class CustomerCardManager {
                 'KYC-formulär klarmarkerat');
         } else {
             this._setTabStatus('kycformular',
-                '<i class="fas fa-exclamation-circle tab-status--warn" aria-hidden="true"></i>',
+                '<i class="fas fa-exclamation-circle tab-status--incomplete" aria-hidden="true"></i>',
                 'KYC-formulär ej klarmarkerat');
         }
 
@@ -704,7 +704,7 @@ class CustomerCardManager {
                 'Uppdragsavtal klarmarkerat');
         } else {
             this._setTabStatus('uppdragsavtal',
-                '<i class="fas fa-exclamation-circle tab-status--warn" aria-hidden="true"></i>',
+                '<i class="fas fa-exclamation-circle tab-status--incomplete" aria-hidden="true"></i>',
                 'Uppdragsavtal ej klarmarkerat');
         }
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,38 +1,62 @@
+@import url('https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,500&display=swap');
+
 /* =====================================
-   ClientFlow – Lila färgskala (matchar inloggningssidan)
+   ClientFlow – Petrol färgskala (sval, ägd)
    ===================================== */
 :root {
   --container-max: 1500px;
 
-  --text: #374151;
-  --title-text: #1e293b;
-  --btn-bg: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  --btn-bg-hover: #5a67d8;
-  --btn-text: #ffffff;
-  --btn-radius: 12px;
-  --title-font: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-  --body-font: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-  --title-weight: 600;
-  --body-weight: 400;
-  --accent: #667eea;
-  --accent-dark: #764ba2;
-  --accent-light: #a5b4fc;
-  --muted: #eef2ff;
-  --muted-alt: #e0e7ff;
-  --border: #c7d2fe;
-  --radius: 12px;
-  --radius-xl: 16px;
+  /* --- Text --- */
+  --text:        #5a626d;   /* var #374151  – sekundär/brödtext, lite svalare */
+  --title-text:  #15181d;   /* var #1e293b  – rubriker, högre kontrast */
+
+  /* --- Knappar: SOLID petrol istället för lila gradient --- */
+  --btn-bg:        #13505c;          /* var linear-gradient(...#667eea...#764ba2) */
+  --btn-bg-hover:  #0d3a43;          /* var #5a67d8 */
+  --btn-text:      #ffffff;
+  --btn-radius:    10px;             /* var 12px – aning stramare */
+
+  /* --- Typsnitt: Schibsted Grotesk (skandinavisk grotesk) --- */
+  --title-font: "Schibsted Grotesk", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  --body-font:  "Schibsted Grotesk", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  --title-weight: 700;               /* var 600 */
+  --body-weight:  400;
+
+  /* --- Accent (petrol – blå-lutande så den ej krockar med grön/röd) --- */
+  --accent:        #13505c;          /* var #667eea */
+  --accent-dark:   #0d3a43;          /* var #764ba2 */
+  --accent-light:  #bcd6da;          /* var #a5b4fc – ljus petrol */
+  --muted:         #e3eef0;          /* var #eef2ff – accent-tint (aktiva ytor) */
+  --muted-alt:     #d3e3e6;          /* var #e0e7ff */
+  --border:        #dcdfe5;          /* var #c7d2fe – neutral sval kant (ej lila) */
+
+  --radius:     12px;
+  --radius-xl:  16px;
+
   --sidebar-bg: #ffffff;
-  --card-bg: #ffffff;
-  --card-shadow: 0 4px 20px rgba(102, 126, 234, 0.08);
-  --success: #16a34a;
-  --warning: #d97706;
-  --error: #dc2626;
+  --card-bg:    #ffffff;
+  --card-shadow: 0 1px 2px rgba(21,24,29,.04), 0 8px 28px rgba(21,24,29,.06); /* var lila skugga */
+
+  /* --- Status: ENBART för sin betydelse --- */
+  --success: #1f8a4c;   /* klar/godkänd */
+  --warning: #b07414;   /* ofullständig / behöver åtgärd  ← använd denna för "ej gjort", inte error */
+  --error:   #c23b2e;   /* verkligt fel / hög risk */
+
+  /* --- NYA hjälpvariabler (för uppstädning av hårdkodade hex) --- */
+  --app-bg:      #f5f6f8;   /* sval sidbakgrund (ersätter lavendel #f5f3ff) */
+  --panel-2:     #fafbfc;   /* nästlad yta */
+  --ink-3:       #8b929d;   /* ikoner i vila, tertiär text */
+  --label:       #9aa1ab;   /* versala fältetiketter / gruppnamn */
+  --line:        #e8eaee;   /* hårfin linje */
+  --success-tint:#e7f3ec;
+  --warning-tint:#f8eed7;
+  --error-tint:  #fbe9e7;
+  --accent-tint: #e3eef0;   /* = --muted, alias för tydlighet */
 }
 
-html { scroll-behavior: smooth; background: #f5f3ff; }
+html { scroll-behavior: smooth; background: var(--app-bg); }
 body {
-  margin: 0; color: var(--text); background: #f5f3ff;
+  margin: 0; color: var(--text); background: var(--app-bg);
   font-family: var(--body-font); font-weight: var(--body-weight);
   -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;
   min-height: 100dvh; overflow-x: hidden;
@@ -1429,7 +1453,11 @@ body.sidebar-collapsed .logout-btn {
 }
 
 .customer-details-section .tab-status--warn {
-    color: #ef4444;
+    color: var(--error);
+}
+
+.customer-details-section .tab-status--incomplete {
+    color: var(--warning);
 }
 
 .customer-details-section .tab-status--ok {
@@ -1468,7 +1496,7 @@ body.sidebar-collapsed .logout-btn {
 }
 
 .customer-details-section .tab-status--bubble-red {
-    background: #ef4444;
+    background: var(--warning);
 }
 
 .customer-details-section .tab-status--bubble-yellow {
@@ -1510,7 +1538,7 @@ body.sidebar-collapsed .logout-btn {
 }
 
 .customer-details-section .tab-status-bubble--red {
-    background: #ef4444;
+    background: var(--warning);
 }
 
 .customer-details-section .tab-status-bubble--yellow {
@@ -5638,8 +5666,8 @@ body.sidebar-collapsed .logout-btn {
     align-items: center;
     gap: 0.75rem;
     padding: 0.75rem;
-    background: #f5f3ff;
-    border: 1px dashed #c4b5fd;
+    background: var(--accent-tint);
+    border: 1px dashed var(--accent-light);
     border-radius: 8px;
     flex-wrap: wrap;
 }
@@ -5648,7 +5676,7 @@ body.sidebar-collapsed .logout-btn {
     align-items: center;
     gap: 0.4rem;
     padding: 0.45rem 1rem;
-    background: #6366f1;
+    background: var(--accent);
     color: #fff;
     border: none;
     border-radius: 6px;
@@ -5658,7 +5686,7 @@ body.sidebar-collapsed .logout-btn {
     transition: background 0.15s;
     white-space: nowrap;
 }
-.btn-ai-suggest:hover { background: #4f46e5; }
+.btn-ai-suggest:hover { background: var(--accent-dark); }
 .btn-ai-suggest:disabled { opacity: 0.6; cursor: not-allowed; }
 
 /* AI "tänker"-indikator – visuell overlay när AI arbetar */
@@ -10761,8 +10789,8 @@ textarea.kunduppgifter-input.uppdrag-run-note[readonly] {
     color: #10b981;
 }
 .kundlista-row-icon--warn {
-    background: #fef2f2;
-    color: #ef4444;
+    background: var(--warning-tint);
+    color: var(--warning);
 }
 .kundlista-row-name {
     display: flex;
@@ -11226,8 +11254,8 @@ textarea.kunduppgifter-input.uppdrag-run-note[readonly] {
     font-weight: 600;
     padding: 0.3rem 0.7rem;
     border-radius: 8px;
-    border: 1px solid rgba(102, 126, 234, 0.3);
-    background: rgba(102, 126, 234, 0.08);
+    border: 1px solid var(--accent-light);
+    background: var(--accent-tint);
     color: var(--accent);
     cursor: pointer;
     transition: all 0.2s ease;
@@ -11241,8 +11269,8 @@ textarea.kunduppgifter-input.uppdrag-run-note[readonly] {
     justify-content: space-between;
     gap: 0.75rem;
     flex-wrap: wrap;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.08));
-    border: 1px solid rgba(102, 126, 234, 0.2);
+    background: var(--accent-tint);
+    border: 1px solid var(--accent-light);
     border-radius: 10px;
     padding: 0.65rem 0.85rem;
     margin-bottom: 1rem;
@@ -11266,13 +11294,13 @@ textarea.kunduppgifter-input.uppdrag-run-note[readonly] {
     padding: 0.45rem 0.95rem;
     border-radius: 10px;
     border: none;
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: var(--accent);
     color: #fff;
     cursor: pointer;
     white-space: nowrap;
-    transition: transform 0.15s ease, opacity 0.2s ease;
+    transition: background 0.15s ease, transform 0.15s ease, opacity 0.2s ease;
 }
-.btn-ai:hover { transform: translateY(-1px); }
+.btn-ai:hover { background: var(--accent-dark); transform: translateY(-1px); }
 .btn-ai:disabled { opacity: 0.7; cursor: progress; }
 .btn-ai.loading i { animation: spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }


### PR DESCRIPTION
## Summary

Omfärgar ClientFlow till det nya svala **petrol-baserade** designsystemet (STEG 1–5 av redesignen). Endast utseende — **ingen** affärslogik, JS-beteende, datahämtning, routing eller API-anrop ändrad. ClientFlow-loggan är orörd.

- **`:root`-tokens** bytta från lila/indigo till petrol; variabelnamn oförändrade så inget binds om. Nya hjälpvariabler (`--app-bg`, `--line`, `--ink-3`, tints m.fl.).
- **Bakgrund:** hårdkodad lavendel `#f5f3ff` på `html`/`body` → `var(--app-bg)`.
- **Typsnitt:** Inter → **Schibsted Grotesk** (+ **Fraunces** för varma kundytor) via `@import`.
- **AI-element** (`.btn-ai`, `.ai-suggest-bar`, `.btn-add-row`, `.btn-ai-suggest`): lila gradient → solid petrol/tint.
- **Färgsemantik:** ej-ifyllda kundkortsflikar (KYC-formulär, Uppdragsavtal, Företagsinfo, Riskbedömning) röd → **amber** via ny klass `tab-status--incomplete`. Öppna avvikelser förblir röda. Kundlistans compliance-ikon + samarbete-bubblan → amber.

Inkluderar referensdokument (`clientflow-design-system.md`, `clientflow-root.css`).

> Obs: STEG 6–9 (åtgärdslista, aktiv navigation, hex-uppstädning, varm kundyta) ligger kvar och kommer i separat PR.

## Test plan

- [ ] Ladda appen och verifiera petrol-paletten (navigation, knappar, kort).
- [ ] Kontrollera att Schibsted Grotesk laddas och slår igenom.
- [ ] KYC-formulär / Uppdragsavtal-flikar visar **amber** när ej klarmarkerade; öppna avvikelser fortfarande röda.
- [ ] AI-knappar/fält är petrol (ingen lila gradient kvar).
- [ ] Inga funktionella regressioner (endast CSS/markup).
