### PR TITLE
Fix Redigera tjänst hot card 3-part layout

### DIFF
--- a/public/js/riskbedomning-byra.v4.js
+++ b/public/js/riskbedomning-byra.v4.js
@@ -531,7 +531,7 @@ class RiskAssessmentManager {
         if (compEl) compEl.textContent = completedCount;
     }
 
-    // ---- Modal: dynamiska rader ----
+    // ---- Modal: dynamiska rader (3-dels kortlayout) ----
     addHotRow(data = {}) {
         const list = document.getElementById('hot-list');
         if (!list) return;
@@ -540,22 +540,26 @@ class RiskAssessmentManager {
         const beskrivning = data.beskrivning ?? data.description ?? '';
         const kalla = data.kalla ?? data.källa ?? data.source ?? '';
         const row = document.createElement('div');
-        row.className = 'dyn-row dyn-row-hot';
+        row.className = 'dyn-row dyn-row-hot dyn-card';
         row.innerHTML = `
-            <select class="dyn-typ">
-                <option value="PT" ${typ === 'TF' ? '' : 'selected'}>PT</option>
-                <option value="TF" ${typ === 'TF' ? 'selected' : ''}>TF</option>
-            </select>
-            <div class="dyn-fields">
-                <input type="text" class="dyn-titel" placeholder="Hotets titel" value="${this.esc(titel)}">
-                <textarea class="dyn-besk" rows="2" placeholder="Tillvägagångssätt">${this.esc(beskrivning)}</textarea>
-                <div class="dyn-kalla-row">
-                    <i class="fas fa-link dyn-kalla-icon" aria-hidden="true"></i>
-                    <input type="text" class="dyn-kalla" placeholder="Källa, t.ex. Finanspolisen eller FATF" value="${this.esc(kalla)}">
-                    <a class="dyn-kalla-link" target="_blank" rel="noopener" style="display:none;">Öppna källa ↗</a>
-                </div>
+            <div class="dyn-row-header">
+                <span class="dyn-drag" title="Dra för att sortera" aria-hidden="true"><i class="fas fa-grip-vertical"></i></span>
+                <select class="dyn-typ" aria-label="Hottyp">
+                    <option value="PT" ${typ === 'TF' ? '' : 'selected'}>PT</option>
+                    <option value="TF" ${typ === 'TF' ? 'selected' : ''}>TF</option>
+                </select>
+                <span class="dyn-header-spacer"></span>
+                <button type="button" class="dyn-remove" title="Ta bort"><i class="fas fa-times"></i></button>
             </div>
-            <button type="button" class="dyn-remove" title="Ta bort"><i class="fas fa-times"></i></button>
+            <div class="dyn-row-body">
+                <input type="text" class="dyn-titel" placeholder="Hotets titel" value="${this.esc(titel)}">
+                <textarea class="dyn-besk" rows="3" placeholder="Beskrivning av hotet">${this.esc(beskrivning)}</textarea>
+            </div>
+            <div class="dyn-kalla-row">
+                <i class="fas fa-link dyn-kalla-icon" aria-hidden="true"></i>
+                <input type="text" class="dyn-kalla" placeholder="Källa, t.ex. Finanspolisen eller FATF" value="${this.esc(kalla)}">
+                <a class="dyn-kalla-link" target="_blank" rel="noopener" hidden>Öppna källa ↗</a>
+            </div>
         `;
         row.querySelector('.dyn-remove').addEventListener('click', () => row.remove());
         const kallaInput = row.querySelector('.dyn-kalla');
@@ -564,10 +568,10 @@ class RiskAssessmentManager {
             const val = kallaInput.value.trim();
             if (this.isKallaUrl(val)) {
                 kallaLink.href = val;
-                kallaLink.style.display = '';
+                kallaLink.hidden = false;
             } else {
                 kallaLink.removeAttribute('href');
-                kallaLink.style.display = 'none';
+                kallaLink.hidden = true;
             }
         };
         kallaInput.addEventListener('input', syncKallaLink);
@@ -589,14 +593,18 @@ class RiskAssessmentManager {
         const beskrivning = data.beskrivning ?? data.description ?? '';
         const opts = kategorier.map(k => `<option value="${k}" ${kategori === k ? 'selected' : ''}>${k}</option>`).join('');
         const row = document.createElement('div');
-        row.className = 'dyn-row dyn-row-sarbarhet';
+        row.className = 'dyn-row dyn-row-sarbarhet dyn-card';
         row.innerHTML = `
-            <select class="dyn-kategori">${opts}</select>
-            <div class="dyn-fields">
-                <input type="text" class="dyn-titel" placeholder="Sårbarhetens titel" value="${this.esc(titel)}">
-                <textarea class="dyn-besk" rows="2" placeholder="Beskrivning">${this.esc(beskrivning)}</textarea>
+            <div class="dyn-row-header">
+                <span class="dyn-drag" title="Dra för att sortera" aria-hidden="true"><i class="fas fa-grip-vertical"></i></span>
+                <select class="dyn-kategori" aria-label="Sårbarhetskategori">${opts}</select>
+                <span class="dyn-header-spacer"></span>
+                <button type="button" class="dyn-remove" title="Ta bort"><i class="fas fa-times"></i></button>
             </div>
-            <button type="button" class="dyn-remove" title="Ta bort"><i class="fas fa-times"></i></button>
+            <div class="dyn-row-body">
+                <input type="text" class="dyn-titel" placeholder="Sårbarhetens titel" value="${this.esc(titel)}">
+                <textarea class="dyn-besk" rows="3" placeholder="Beskrivning av sårbarheten">${this.esc(beskrivning)}</textarea>
+            </div>
         `;
         row.querySelector('.dyn-remove').addEventListener('click', () => row.remove());
         list.appendChild(row);
@@ -605,16 +613,21 @@ class RiskAssessmentManager {
     addAtgardRow(data = {}) {
         const list = document.getElementById('atgard-list');
         if (!list) return;
-        const titel = data.titel ?? data.title ?? '';
+        const titel = data.titel ?? data.title ?? data.namn ?? '';
         const beskrivning = data.beskrivning ?? data.description ?? '';
         const row = document.createElement('div');
-        row.className = 'dyn-row dyn-row-atgard';
+        row.className = 'dyn-row dyn-row-atgard dyn-card';
         row.innerHTML = `
-            <div class="dyn-fields">
-                <input type="text" class="dyn-titel" placeholder="Åtgärdens titel" value="${this.esc(titel)}">
-                <textarea class="dyn-besk" rows="2" placeholder="Vad kontrolleras och dokumenteras?">${this.esc(beskrivning)}</textarea>
+            <div class="dyn-row-header">
+                <span class="dyn-drag" title="Dra för att sortera" aria-hidden="true"><i class="fas fa-grip-vertical"></i></span>
+                <span class="dyn-header-label">Åtgärd</span>
+                <span class="dyn-header-spacer"></span>
+                <button type="button" class="dyn-remove" title="Ta bort"><i class="fas fa-times"></i></button>
             </div>
-            <button type="button" class="dyn-remove" title="Ta bort"><i class="fas fa-times"></i></button>
+            <div class="dyn-row-body">
+                <input type="text" class="dyn-titel" placeholder="Åtgärdens titel" value="${this.esc(titel)}">
+                <textarea class="dyn-besk" rows="3" placeholder="Vad kontrolleras och dokumenteras?">${this.esc(beskrivning)}</textarea>
+            </div>
         `;
         row.querySelector('.dyn-remove').addEventListener('click', () => row.remove());
         list.appendChild(row);
@@ -872,6 +885,6 @@ function closeModal(modalId) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    console.info('[ClientFlow] riskbedomning-byra v3 laddad – formuläret visar titel + beskrivning för hot/sårbarheter/åtgärder.');
+    console.info('[ClientFlow] riskbedomning-byra v4 laddad – kortlayout med titel, beskrivning och källa.');
     window.riskManager = new RiskAssessmentManager();
 });

--- a/public/riskbedomning-byra.html
+++ b/public/riskbedomning-byra.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClientFlow • Riskbedömning av byråns tjänster</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Merriweather+Sans:wght@600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=20260605b">
+    <link rel="stylesheet" href="styles.css?v=20260605c">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
 </head>
 <body>
@@ -210,6 +210,6 @@
     <script src="js/navigation.js"></script>
     <script src="js/components.js"></script>
     <script src="app.js?v=1.1"></script>
-    <script src="js/riskbedomning-byra.v3.js"></script>
+    <script src="js/riskbedomning-byra.v4.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -11318,74 +11318,122 @@ textarea.kunduppgifter-input.uppdrag-run-note[readonly] {
 .btn-ai.loading i { animation: spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
-/* Dynamiska rader i modalen */
-.dyn-list { display: flex; flex-direction: column; gap: 0.55rem; }
-.dyn-row {
+/* Dynamiska rader i modalen – 3-dels kortlayout */
+.dyn-list { display: flex; flex-direction: column; gap: 0.65rem; }
+
+.dyn-row.dyn-card {
     display: flex;
-    align-items: flex-start;
-    gap: 0.55rem;
-    background: #f8fafc;
-    border: 1px solid #eef2f7;
+    flex-direction: column;
+    padding: 0;
+    overflow: hidden;
+    background: var(--card-bg, #fff);
+    border: 1px solid var(--line, #e8eaee);
     border-radius: 10px;
-    padding: 0.55rem 0.65rem;
 }
-.dyn-row .dyn-fields { flex: 1; display: flex; flex-direction: column; gap: 0.4rem; min-width: 0; }
+
+.dyn-row-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 0.65rem;
+    background: var(--panel-2, #fafbfc);
+    border-bottom: 1px solid var(--line, #e8eaee);
+}
+
+.dyn-drag {
+    color: var(--ink-3, #8b929d);
+    cursor: grab;
+    font-size: 0.85rem;
+    line-height: 1;
+    flex-shrink: 0;
+    user-select: none;
+}
+
+.dyn-header-spacer { flex: 1; min-width: 0; }
+
+.dyn-header-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--label, #9aa1ab);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
 .dyn-row .dyn-typ,
 .dyn-row .dyn-kategori {
     flex-shrink: 0;
-    align-self: flex-start;
     font-size: 0.8rem;
-    padding: 0.35rem 0.4rem;
+    padding: 0.35rem 0.5rem;
     border: 1px solid #cbd5e1;
     border-radius: 8px;
     background: #fff;
 }
+
+.dyn-row .dyn-typ { min-width: 72px; }
 .dyn-row .dyn-kategori { min-width: 120px; }
-.dyn-row .dyn-titel,
-.dyn-row .dyn-besk {
+
+.dyn-row-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 0.55rem 0.65rem;
+}
+
+.dyn-row-body .dyn-titel,
+.dyn-row-body .dyn-besk {
     width: 100%;
+    box-sizing: border-box;
     font-size: 0.85rem;
-    padding: 0.4rem 0.55rem;
+    padding: 0.45rem 0.55rem;
     border: 1px solid #d7dee8;
     border-radius: 8px;
     background: #fff;
     font-family: inherit;
 }
-.dyn-row .dyn-besk { resize: vertical; }
-/* Diskret källrad längst ned i hot-kortet (källhänvisning + ev. länk) */
-.dyn-row .dyn-kalla-row {
+
+.dyn-row-body .dyn-titel { font-weight: 600; }
+.dyn-row-body .dyn-besk { resize: vertical; min-height: 4.5rem; }
+
+/* Diskret källrad längst ned i hot-kortet */
+.dyn-card .dyn-kalla-row {
     display: flex;
     align-items: center;
     gap: 6px;
-    border-top: 0.5px solid var(--line);
-    padding-top: 6px;
-    margin-top: 2px;
+    border-top: 0.5px solid var(--line, #e8eaee);
+    padding: 6px 12px;
+    background: var(--card-bg, #fff);
 }
-.dyn-row .dyn-kalla-icon {
+
+.dyn-card .dyn-kalla-icon {
     font-size: 14px;
-    color: var(--ink-3);
+    color: var(--ink-3, #8b929d);
     flex-shrink: 0;
 }
-.dyn-row .dyn-kalla {
+
+.dyn-card .dyn-kalla {
     flex: 1;
     min-width: 0;
     border: none;
     background: transparent;
     font-size: 12px;
-    color: var(--text);
+    color: var(--text, #5a626d);
     font-family: inherit;
     padding: 2px 0;
 }
-.dyn-row .dyn-kalla:focus { outline: none; }
-.dyn-row .dyn-kalla-link {
+
+.dyn-card .dyn-kalla:focus { outline: none; }
+
+.dyn-card .dyn-kalla-link {
     flex-shrink: 0;
     font-size: 11px;
     white-space: nowrap;
-    color: var(--accent);
+    color: var(--accent, #13505c);
     text-decoration: none;
 }
-.dyn-row .dyn-kalla-link:hover { text-decoration: underline; }
-.dyn-remove {
+
+.dyn-card .dyn-kalla-link:hover { text-decoration: underline; }
+
+.dyn-row-header .dyn-remove {
     flex-shrink: 0;
     width: 28px;
     height: 28px;
@@ -11399,4 +11447,5 @@ textarea.kunduppgifter-input.uppdrag-run-note[readonly] {
     justify-content: center;
     transition: background 0.2s ease;
 }
-.dyn-remove:hover { background: #fecaca; }
+
+.dyn-row-header .dyn-remove:hover { background: #fecaca; }


### PR DESCRIPTION
## Summary
- Rebuild hot/sarbarhet/atgard rows as vertical 3-part cards (header with drag+dropdown+trash, body with titel+beskrivning, footer with kalla for hot)
- Fix CSS so title and description fields are visible instead of broken horizontal flex layout
- Ship as riskbedomning-byra.v4.js with styles.css?v=20260605c cache bust

## Test plan
- [ ] Open Redigera tjänst for Löpande bokföring
- [ ] Each hot shows header bar, title input, description textarea, and källa row at bottom
- [ ] Generera med AI populates all fields
- [ ] Save and reopen preserves titel, beskrivning, kalla
- [ ] Öppna källa link appears only for http URLs

Made with [Cursor](https://cursor.com)