### PR TITLE
Fix: skapa uppdragskörningar för nya löneuppdragstyper

### DIFF
--- a/index.js
+++ b/index.js
@@ -7097,15 +7097,212 @@ async function sendSamarbeteDigestEmail({ toEmail, toName, senderByra, senderLog
   }
 }
 
+function toIsoDateOnly(v) {
+  const s = String(v || '').slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : '';
+}
+
+async function ensureUppdragRunsSchema(airtableAccessToken, baseId) {
+  try {
+    await ensureUppdragTypChoices(airtableAccessToken, baseId);
+    await ensureUppdragRunsTypChoices(airtableAccessToken, baseId);
+    await ensureUppdragRunsStatusChoices(airtableAccessToken, baseId);
+  } catch (_) {}
+}
+
+async function ensureRunsAheadForUppdrag(uppdragRec, ctx) {
+  const {
+    airtableAccessToken,
+    airtableBaseId,
+    todayIso,
+    todayYm,
+    uppdragRunsUrl
+  } = ctx || {};
+  const toIsoDate = toIsoDateOnly;
+  const r = uppdragRec;
+  const f = r?.fields || {};
+  const uppdragId = String(r?.id || '').trim();
+  if (!uppdragId) return { created: 0, skipped: true, reason: 'missing_id' };
+  if ((f['Status'] || 'Aktiv') !== 'Aktiv') return { created: 0, skipped: true, reason: 'not_active' };
+  const typ = String(f['Typ'] || '').trim();
+  if (!typ) return { created: 0, skipped: true, reason: 'missing_typ' };
+  const freq = String(f['Frekvens'] || '').trim();
+  const deadline0 = toIsoDate(f['Nästa deadline'] || '');
+  const freqLow = freq.toLowerCase();
+  const isMomsSched = typ === 'Momsredovisning' && (freqLow.includes('månad') || freqLow.includes('kvartal'));
+  if (!deadline0 && !isMomsSched) return { created: 0, skipped: true, reason: 'missing_deadline' };
+
+  const avslutasIso = toIsoDate(f['Avslutas'] || '');
+  let horizonEnd = addMonthsIso(todayIso, 12) || todayIso;
+  if (avslutasIso && avslutasIso < horizonEnd) horizonEnd = avslutasIso;
+  const horizonYm = horizonEnd.slice(0, 7);
+
+  if (!uppdragRunsUrl) return { created: 0, skipped: true, reason: 'runs_table_missing' };
+
+  const existing = new Map();
+  try {
+    const formula = encodeURIComponent(`{Uppdrag ID} = "${uppdragId.replace(/"/g, '\\"')}"`);
+    const res = await axios.get(`${uppdragRunsUrl}?filterByFormula=${formula}&pageSize=100`, { headers: { Authorization: `Bearer ${airtableAccessToken}` } });
+    (res.data.records || []).forEach(rr => {
+      const key = String(rr?.fields?.['Run Key'] || '').trim();
+      if (key) existing.set(key, rr);
+    });
+  } catch (_) {}
+
+  const nowIso = new Date().toISOString();
+  let created = 0;
+  const createRun = async ({ periodKey, periodLabel, deadlineIso, startIso }) => {
+    if (avslutasIso && deadlineIso && deadlineIso > avslutasIso) return;
+    if (avslutasIso && startIso && startIso > avslutasIso) return;
+    const runKey = `${uppdragId}:${periodKey}`;
+    const existingRun = existing.get(runKey);
+    if (existingRun) {
+      const expectedStart = toIsoDate(startIso || '');
+      const currentStart = toIsoDate(existingRun?.fields?.['Startdatum'] || '');
+      if (expectedStart && expectedStart !== currentStart && existingRun?.id) {
+        try {
+          await axios.patch(
+            `${uppdragRunsUrl}/${existingRun.id}`,
+            { fields: { 'Startdatum': expectedStart, 'Uppdaterad': nowIso } },
+            { headers: { Authorization: `Bearer ${airtableAccessToken}`, 'Content-Type': 'application/json' } }
+          );
+          existingRun.fields = { ...(existingRun.fields || {}), Startdatum: expectedStart };
+        } catch (e) {
+          const msg = e.response?.data?.error?.message || e.message;
+          console.warn(`ensureRunsAheadForUppdrag: kunde inte uppdatera startdatum för ${runKey}:`, msg);
+        }
+      }
+      return;
+    }
+    try {
+      const runFields = {
+        'Run Key': runKey,
+        'Uppdrag ID': uppdragId,
+        'Kund ID': String(f['Kund ID'] || '').trim(),
+        'Byrå ID': String(f['Byrå ID'] || '').trim(),
+        'Typ': typ,
+        'Frekvens': freq,
+        'PeriodKey': periodKey,
+        'Period Label': periodLabel,
+        'Deadline': deadlineIso,
+        'Status': 'Planerad',
+        'Skapad': nowIso,
+        'Uppdaterad': nowIso
+      };
+      if (startIso) runFields['Startdatum'] = startIso;
+      await axios.post(
+        uppdragRunsUrl,
+        { fields: runFields },
+        { headers: { Authorization: `Bearer ${airtableAccessToken}`, 'Content-Type': 'application/json' } }
+      );
+      existing.set(runKey, { id: null, fields: { 'Run Key': runKey, Startdatum: startIso } });
+      created += 1;
+    } catch (e) {
+      const msg = e.response?.data?.error?.message || e.message;
+      console.warn(`ensureRunsAheadForUppdrag: kunde inte skapa körning ${runKey} (${typ}):`, msg);
+    }
+  };
+
+  if (typ === 'Momsredovisning' && (freqLow.includes('månad') || freqLow.includes('kvartal'))) {
+    let firstPk = momsInferFirstPeriod(f, freq);
+    if (!firstPk) firstPk = momsDefaultPeriodKeyForBoard(todayYm, freq) || todayYm;
+    const momsRuns = momsRunsThroughHorizon(firstPk, freq, todayYm);
+    for (const run of momsRuns) {
+      // eslint-disable-next-line no-await-in-loop
+      await createRun({
+        periodKey: run.periodKey,
+        periodLabel: run.periodLabel,
+        deadlineIso: run.deadlineIso,
+        startIso: run.startIso
+      });
+    }
+    return { created, skipped: false };
+  }
+
+  if (isLoneUppdragTyp(typ) && freqLow.includes('månad')) {
+    const templateStart = toIsoDate(f['Startdatum'] || '') || deadline0;
+    const templateDeadline = deadline0;
+    if (!templateStart || !templateDeadline) return { created: 0, skipped: true, reason: 'missing_lone_template_dates' };
+    const loneRuns = loneRunsThroughHorizon(templateStart, templateDeadline, typ, todayYm);
+    for (const run of loneRuns) {
+      // eslint-disable-next-line no-await-in-loop
+      await createRun({
+        periodKey: run.periodKey,
+        periodLabel: run.periodLabel,
+        deadlineIso: run.deadlineIso,
+        startIso: run.startIso
+      });
+    }
+    return { created, skipped: false };
+  }
+
+  if (freqLow.includes('månad')) {
+    const day = parseInt(String(deadline0).slice(8, 10), 10);
+    const dayClamped = (Number.isFinite(day) && day >= 1 && day <= 28) ? day : 15;
+    for (let i = 0; i < 12; i++) {
+      const ym = monthAdd(todayYm, i);
+      if (!ym) continue;
+      if (ym > horizonYm) break;
+      const deadlineIso = `${ym}-${String(dayClamped).padStart(2, '0')}`;
+      // eslint-disable-next-line no-await-in-loop
+      await createRun({ periodKey: ym, periodLabel: monthLabelSv(ym), deadlineIso });
+    }
+    return { created, skipped: false };
+  }
+
+  let cur = deadline0;
+  for (let guard = 0; guard < 40; guard++) {
+    if (!cur) break;
+    if (cur > horizonEnd) break;
+
+    let periodKey = cur.slice(0, 7);
+    let periodLabel = monthLabelSv(periodKey);
+    if (freqLow.includes('kvartal')) {
+      const q = currentQuarterFromYm(periodKey);
+      periodKey = q ? `${q.year}-Q${q.quarter}` : periodKey;
+      periodLabel = quarterLabelSv(periodKey) || periodLabel;
+    } else if (freqLow.includes('årsvis') || freqLow.includes('år')) {
+      periodKey = cur.slice(0, 4);
+      periodLabel = periodKey;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await createRun({ periodKey, periodLabel, deadlineIso: cur });
+    cur = calcNextDeadline(cur, freq) || '';
+  }
+  return { created, skipped: false };
+}
+
+async function buildEnsureRunsContext(airtableAccessToken, baseId) {
+  const todayIso = stockholmDateStr(new Date());
+  const todayYm = todayIso.slice(0, 7);
+  const uppdragRunsTableId = await resolveUppdragRunsTableId(airtableAccessToken, baseId);
+  const uppdragRunsUrl = uppdragRunsTableId
+    ? `https://api.airtable.com/v0/${baseId}/${uppdragRunsTableId}`
+    : null;
+  return { todayIso, todayYm, uppdragRunsUrl, uppdragRunsTableId };
+}
+
+async function ensureRunsForUppdragRecord(record, airtableAccessToken, baseId) {
+  if (!record?.id) return { created: 0, skipped: true, reason: 'missing_record' };
+  await ensureUppdragRunsSchema(airtableAccessToken, baseId);
+  const ctx = await buildEnsureRunsContext(airtableAccessToken, baseId);
+  if (!ctx.uppdragRunsUrl) return { created: 0, skipped: true, reason: 'runs_table_missing' };
+  return ensureRunsAheadForUppdrag(record, {
+    airtableAccessToken,
+    airtableBaseId: baseId,
+    todayIso: ctx.todayIso,
+    todayYm: ctx.todayYm,
+    uppdragRunsUrl: ctx.uppdragRunsUrl
+  });
+}
+
 async function processUppdragUnderlagSchedule() {
   const airtableAccessToken = process.env.AIRTABLE_ACCESS_TOKEN;
   const airtableBaseId = process.env.AIRTABLE_BASE_ID || 'appPF8F7VvO5XYB50';
   if (!airtableAccessToken) return;
 
-  const toIsoDate = (v) => {
-    const s = String(v || '').slice(0, 10);
-    return /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : '';
-  };
+  const toIsoDate = toIsoDateOnly;
 
   // Försök säkerställa att Uppdrag-tabellen har fälten (kräver schema-token). Körs tyst.
   try {
@@ -7149,6 +7346,8 @@ async function processUppdragUnderlagSchedule() {
     }
   } catch (_) {}
 
+  await ensureUppdragRunsSchema(airtableAccessToken, airtableBaseId);
+
   const todayIso = stockholmDateStr(new Date()); // YYYY-MM-DD
   const todayDay = parseInt(todayIso.slice(8, 10), 10);
   const todayYm = todayIso.slice(0, 7);
@@ -7178,163 +7377,17 @@ async function processUppdragUnderlagSchedule() {
   let uppdragRecords = [];
   try { uppdragRecords = await fetchActive(); } catch (_) { uppdragRecords = await fetchAll(); }
 
-  // Säkerställ att körningar finns 12 månader framåt (per uppdrag och frekvens).
-  // Körs innan vi skapar dagens auto-underlag så att vi alltid kan koppla till en körning.
-  const ensureRunsAheadForUppdrag = async (uppdragRec) => {
-    const r = uppdragRec;
-    const f = r?.fields || {};
-    const uppdragId = String(r?.id || '').trim();
-    if (!uppdragId) return;
-    if ((f['Status'] || 'Aktiv') !== 'Aktiv') return;
-    const typ = String(f['Typ'] || '').trim();
-    if (!typ) return;
-    const freq = String(f['Frekvens'] || '').trim();
-    const deadline0 = toIsoDate(f['Nästa deadline'] || '');
-    const freqLow = freq.toLowerCase();
-    const isMomsSched = typ === 'Momsredovisning' && (freqLow.includes('månad') || freqLow.includes('kvartal'));
-    if (!deadline0 && !isMomsSched) return;
-
-    const avslutasIso = toIsoDate(f['Avslutas'] || '');
-    let horizonEnd = addMonthsIso(todayIso, 12) || todayIso;
-    if (avslutasIso && avslutasIso < horizonEnd) horizonEnd = avslutasIso;
-    const horizonYm = horizonEnd.slice(0, 7);
-
-    if (!uppdragRunsUrl) return;
-
-    // Hämta existerande körningar för uppdraget
-    const existing = new Map();
-    try {
-      const formula = encodeURIComponent(`{Uppdrag ID} = "${uppdragId.replace(/"/g, '\\"')}"`);
-      const res = await axios.get(`${uppdragRunsUrl}?filterByFormula=${formula}&pageSize=100`, { headers: { Authorization: `Bearer ${airtableAccessToken}` } });
-      (res.data.records || []).forEach(rr => {
-        const key = String(rr?.fields?.['Run Key'] || '').trim();
-        if (key) existing.set(key, rr);
-      });
-    } catch (_) {}
-
-    const nowIso = new Date().toISOString();
-    const createRun = async ({ periodKey, periodLabel, deadlineIso, startIso }) => {
-      if (avslutasIso && deadlineIso && deadlineIso > avslutasIso) return;
-      if (avslutasIso && startIso && startIso > avslutasIso) return;
-      const runKey = `${uppdragId}:${periodKey}`;
-      const existingRun = existing.get(runKey);
-      if (existingRun) {
-        const expectedStart = toIsoDate(startIso || '');
-        const currentStart = toIsoDate(existingRun?.fields?.['Startdatum'] || '');
-        if (expectedStart && expectedStart !== currentStart && existingRun?.id) {
-          try {
-            await axios.patch(
-              `${uppdragRunsUrl}/${existingRun.id}`,
-              { fields: { 'Startdatum': expectedStart, 'Uppdaterad': nowIso } },
-              { headers: { Authorization: `Bearer ${airtableAccessToken}`, 'Content-Type': 'application/json' } }
-            );
-            existingRun.fields = { ...(existingRun.fields || {}), Startdatum: expectedStart };
-          } catch (_) {}
-        }
-        return;
-      }
-      try {
-        const runFields = {
-          'Run Key': runKey,
-          'Uppdrag ID': uppdragId,
-          'Kund ID': String(f['Kund ID'] || '').trim(),
-          'Byrå ID': String(f['Byrå ID'] || '').trim(),
-          'Typ': typ,
-          'Frekvens': freq,
-          'PeriodKey': periodKey,
-          'Period Label': periodLabel,
-          'Deadline': deadlineIso,
-          'Status': 'Planerad',
-          'Skapad': nowIso,
-          'Uppdaterad': nowIso
-        };
-        if (startIso) runFields['Startdatum'] = startIso;
-        await axios.post(
-          uppdragRunsUrl,
-          { fields: runFields },
-          { headers: { Authorization: `Bearer ${airtableAccessToken}`, 'Content-Type': 'application/json' } }
-        );
-        existing.set(runKey, { id: null, fields: { 'Run Key': runKey, Startdatum: startIso } });
-      } catch (_) {}
-    };
-
-    // Momsredovisning: SKV-deadlines + tydliga periodetiketter, 12 månader (eller 4 kvartal) framåt.
-    if (typ === 'Momsredovisning' && (freqLow.includes('månad') || freqLow.includes('kvartal'))) {
-      let firstPk = momsInferFirstPeriod(f, freq);
-      if (!firstPk) firstPk = momsDefaultPeriodKeyForBoard(todayYm, freq) || todayYm;
-      const momsRuns = momsRunsThroughHorizon(firstPk, freq, todayYm);
-      for (const run of momsRuns) {
-        // eslint-disable-next-line no-await-in-loop
-        await createRun({
-          periodKey: run.periodKey,
-          periodLabel: run.periodLabel,
-          deadlineIso: run.deadlineIso,
-          startIso: run.startIso
-        });
-      }
-      return;
-    }
-
-    // Löneuppdrag (innevarande/efterhand/legacy): rullande 12 månader från mall start/deadline.
-    if (isLoneUppdragTyp(typ) && freqLow.includes('månad')) {
-      const templateStart = toIsoDate(f['Startdatum'] || '') || deadline0;
-      const templateDeadline = deadline0;
-      if (!templateStart || !templateDeadline) return;
-      const loneRuns = loneRunsThroughHorizon(templateStart, templateDeadline, typ, todayYm);
-      for (const run of loneRuns) {
-        // eslint-disable-next-line no-await-in-loop
-        await createRun({
-          periodKey: run.periodKey,
-          periodLabel: run.periodLabel,
-          deadlineIso: run.deadlineIso,
-          startIso: run.startIso
-        });
-      }
-      return;
-    }
-
-    // Övriga månadsuppdrag: 12 körningar från innevarande månad.
-    if (freqLow.includes('månad')) {
-      const day = parseInt(String(deadline0).slice(8, 10), 10);
-      const dayClamped = (Number.isFinite(day) && day >= 1 && day <= 28) ? day : 15;
-      for (let i = 0; i < 12; i++) {
-        const ym = monthAdd(todayYm, i);
-        if (!ym) continue;
-        if (ym > horizonYm) break;
-        const deadlineIso = `${ym}-${String(dayClamped).padStart(2, '0')}`;
-        // eslint-disable-next-line no-await-in-loop
-        await createRun({ periodKey: ym, periodLabel: monthLabelSv(ym), deadlineIso });
-      }
-      return;
-    }
-
-    // Kvartal/År/Engång: behåll tidigare logik (iterera från nästa deadline fram till horisont)
-    let cur = deadline0;
-    for (let guard = 0; guard < 40; guard++) {
-      if (!cur) break;
-      if (cur > horizonEnd) break;
-
-      let periodKey = cur.slice(0, 7);
-      let periodLabel = monthLabelSv(periodKey);
-      if (freqLow.includes('kvartal')) {
-        const q = currentQuarterFromYm(periodKey);
-        periodKey = q ? `${q.year}-Q${q.quarter}` : periodKey;
-        periodLabel = quarterLabelSv(periodKey) || periodLabel;
-      } else if (freqLow.includes('årsvis') || freqLow.includes('år')) {
-        periodKey = cur.slice(0, 4);
-        periodLabel = periodKey;
-      }
-
-      // eslint-disable-next-line no-await-in-loop
-      await createRun({ periodKey, periodLabel, deadlineIso: cur });
-      cur = calcNextDeadline(cur, freq) || '';
-    }
-  };
-
   // Batch: kör för alla uppdrag (best effort)
+  const runsCtx = {
+    airtableAccessToken,
+    airtableBaseId,
+    todayIso,
+    todayYm,
+    uppdragRunsUrl
+  };
   for (const r of uppdragRecords) {
     // eslint-disable-next-line no-await-in-loop
-    await ensureRunsAheadForUppdrag(r);
+    await ensureRunsAheadForUppdrag(r, runsCtx);
   }
 
   const toCreate = [];
@@ -13163,6 +13216,64 @@ app.get('/api/uppdrag/runs', authenticateToken, async (req, res) => {
   }
 });
 
+// POST /api/uppdrag/ensure-runs – säkerställ/generera uppdragskörningar för kund (eller alla aktiva uppdrag)
+// Body/query: { customerId? }
+app.post('/api/uppdrag/ensure-runs', authenticateToken, async (req, res) => {
+  try {
+    const airtableAccessToken = process.env.AIRTABLE_ACCESS_TOKEN;
+    if (!airtableAccessToken) return res.status(500).json({ error: 'AIRTABLE_ACCESS_TOKEN saknas' });
+    const tableIdOrName = process.env.AIRTABLE_TABLE_UPPDRAG_ID || encodeURIComponent(UPPDRAG_TABLE_NAME);
+    const customerId = String((req.body && req.body.customerId) || req.query.customerId || '').trim();
+
+    const userData = await getUser(req.user.email);
+    const byraIdClean = userData?.byraId ? String(userData.byraId).replace(/,/g, '').trim() : '';
+    if (!byraIdClean) return res.status(403).json({ error: 'Saknar byråkoppling (user.byraId)' });
+
+    const uppdragUrl = `https://api.airtable.com/v0/${airtableBaseId}/${tableIdOrName}`;
+    const headers = { Authorization: `Bearer ${airtableAccessToken}` };
+    let records = [];
+    if (customerId) {
+      const listRes = await airtableListWithFormulaFallback({
+        url: uppdragUrl,
+        headers,
+        baseParams: { maxRecords: 100 },
+        formulas: buildUppdragFilterFormulas(customerId)
+      });
+      records = (listRes.data.records || []).filter(r => {
+        const f = r?.fields || {};
+        const recByra = (f['Byrå ID'] != null) ? String(f['Byrå ID']).replace(/,/g, '').trim() : '';
+        return recByra === byraIdClean;
+      });
+    } else {
+      const formula = encodeURIComponent(`AND({Status}="Aktiv",{Byrå ID}="${byraIdClean.replace(/"/g, '\\"')}")`);
+      const listRes = await axios.get(`${uppdragUrl}?filterByFormula=${formula}&pageSize=100`, { headers });
+      records = listRes.data.records || [];
+    }
+
+    const results = [];
+    let totalCreated = 0;
+    for (const rec of records) {
+      // eslint-disable-next-line no-await-in-loop
+      const r = await ensureRunsForUppdragRecord(rec, airtableAccessToken, airtableBaseId);
+      results.push({ uppdragId: rec.id, typ: rec?.fields?.['Typ'] || '', ...r });
+      totalCreated += Number(r?.created || 0);
+    }
+
+    return res.json({
+      ok: true,
+      customerId: customerId || null,
+      processed: results.length,
+      totalCreated,
+      results
+    });
+  } catch (error) {
+    console.error('❌ POST /api/uppdrag/ensure-runs:', error.response?.data || error.message);
+    const status = error.response?.status || 500;
+    const msg = error.response?.data?.error?.message || error.message;
+    res.status(status).json({ error: msg });
+  }
+});
+
 // PATCH /api/uppdrag/runs/:runId/status – uppdatera status på en uppdragskörning
 // Body: { status }
 app.patch('/api/uppdrag/runs/:runId/status', authenticateToken, async (req, res) => {
@@ -13379,10 +13490,13 @@ app.post('/api/uppdrag', authenticateToken, async (req, res) => {
       const record = await tryWriteWithFallback(write);
       const warning = record && record.__clientflow_warning;
       if (warning) delete record.__clientflow_warning;
-      setImmediate(() => {
-        processUppdragUnderlagSchedule().catch((e) => console.warn('ensure runs after uppdrag update:', e.message));
-      });
-      return res.json({ record, updated: true, warning });
+      let runsEnsure = null;
+      try {
+        runsEnsure = await ensureRunsForUppdragRecord(record, airtableAccessToken, airtableBaseId);
+      } catch (e) {
+        console.warn('ensure runs after uppdrag update:', e.message);
+      }
+      return res.json({ record, updated: true, warning, runsEnsure });
     }
 
     const write = async (payloadFields) => {
@@ -13397,10 +13511,13 @@ app.post('/api/uppdrag', authenticateToken, async (req, res) => {
     const record = await tryWriteWithFallback(write);
     const warning = record && record.__clientflow_warning;
     if (warning) delete record.__clientflow_warning;
-    setImmediate(() => {
-      processUppdragUnderlagSchedule().catch((e) => console.warn('ensure runs after uppdrag create:', e.message));
-    });
-    return res.json({ record, created: true, warning });
+    let runsEnsure = null;
+    try {
+      runsEnsure = await ensureRunsForUppdragRecord(record, airtableAccessToken, airtableBaseId);
+    } catch (e) {
+      console.warn('ensure runs after uppdrag create:', e.message);
+    }
+    return res.json({ record, created: true, warning, runsEnsure });
   } catch (error) {
     console.error('❌ POST /api/uppdrag:', error.response?.data || error.message);
     const status = error.response?.status || 500;

--- a/public/js/kundkort.js
+++ b/public/js/kundkort.js
@@ -1245,9 +1245,28 @@ class CustomerCardManager {
             </div>
         ` : '';
 
+        const runsEnsureHtml = (!runsData.tableMissing && records.length > 0 && runRecords.length === 0) ? `
+            <div class="collapsible-card uppdrag-setup-card" style="margin-bottom:1rem;">
+                <div class="collapsible-header" style="cursor:default;">
+                    <div class="collapsible-title"><i class="fas fa-sync-alt"></i><span>Generera uppdragskörningar</span></div>
+                </div>
+                <div class="collapsible-body">
+                    <div class="uppdrag-setup-desc">
+                        Uppdrag finns men inga körningar har skapats i Airtable ännu. Det kan bero på att nya uppdragstyper (t.ex. löneuppdrag innevarande/efterhand) saknades i tabellen när uppdraget lades upp.
+                    </div>
+                    <div class="uppdrag-actions" style="margin-top:0.75rem;">
+                        <button type="button" class="btn btn-primary" id="uppdrag-ensure-runs-btn">
+                            <i class="fas fa-play"></i> Generera körningar
+                        </button>
+                    </div>
+                </div>
+            </div>
+        ` : '';
+
         container.innerHTML = `
             <div class="uppdrag-tab">
                 ${runsSetupHtml}
+                ${runsEnsureHtml}
                 ${boardHtml}
                 <div id="kund-uppdrag-edit-host" style="display:none; margin-top:1rem;">
                     ${existingTypes.length ? existingTypes.map(t => {
@@ -1806,6 +1825,30 @@ class CustomerCardManager {
                     this.showNotification('Kunde inte skapa tabellen: ' + (e.message || 'fel'), 'error');
                     installRunsBtn.disabled = false;
                     installRunsBtn.innerHTML = '<i class="fas fa-magic"></i> Skapa Uppdragskörningar';
+                }
+            });
+        }
+
+        const ensureRunsBtn = document.getElementById('uppdrag-ensure-runs-btn');
+        if (ensureRunsBtn) {
+            ensureRunsBtn.addEventListener('click', async () => {
+                try {
+                    ensureRunsBtn.disabled = true;
+                    ensureRunsBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Genererar...';
+                    const res = await fetch(`${baseUrl}/api/uppdrag/ensure-runs`, {
+                        method: 'POST',
+                        ...opts,
+                        body: JSON.stringify({ customerId })
+                    });
+                    const data = await res.json().catch(() => ({}));
+                    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+                    const n = Number(data.totalCreated || 0);
+                    this.showNotification(n > 0 ? `${n} körning(ar) skapade ✅` : 'Körningar är redan uppdaterade', n > 0 ? 'success' : 'info');
+                    this.loadUppdrag();
+                } catch (e) {
+                    this.showNotification('Kunde inte generera körningar: ' + (e.message || 'fel'), 'error');
+                    ensureRunsBtn.disabled = false;
+                    ensureRunsBtn.innerHTML = '<i class="fas fa-play"></i> Generera körningar';
                 }
             });
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

När löneuppdrag av typerna **Löneuppdrag innevarande** eller **Löneuppdrag efterhand** skapades genererades inga rader i Airtable-tabellen `Uppdragskörningar`. I uppdragsvyn visades därför statusen "Ingen körning" utan möjlighet att åtgärda det.

## Orsak

1. De nya uppdragstyperna fanns inte automatiskt som val i Airtable-fältet `Typ` på `Uppdragskörningar`-tabellen (om tabellen skapades innan typerna lades till).
2. Körningsskapande kördes bara via ett bakgrundsjobb (`setImmediate`) efter sparning – inte synkront.
3. Fel vid skapande av körningar loggades inte (tyst `catch`), vilket gjorde felet svårt att upptäcka.

## Lösning

- Säkerställer automatiskt att `Typ`- och `Status`-val finns i både `Uppdrag` och `Uppdragskörningar` innan körningar genereras.
- Skapar körningar **direkt** när ett uppdrag sparas (skapa/uppdatera).
- Loggar fel om en körning inte kan skapas i Airtable.
- Ny endpoint: `POST /api/uppdrag/ensure-runs` (med `customerId`) för att reparera befintliga uppdrag.
- Ny knapp **"Generera körningar"** i uppdragsvyn när uppdrag finns men inga körningar har skapats.

## Testning

1. Lägg upp ett nytt löneuppdrag (innevarande eller efterhand) med startdatum och deadline.
2. Verifiera att rader skapas i `Uppdragskörningar` i Airtable.
3. För befintliga uppdrag utan körningar: använd knappen **Generera körningar** i uppdragsvyn.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

