### PR TITLE
Fix: lönekörningar syns bara under öppen period

### DIFF
--- a/public/js/kundkort.js
+++ b/public/js/kundkort.js
@@ -1220,6 +1220,13 @@ class CustomerCardManager {
                     }
                 }
             }
+            const start0 = toDateStr(f['Startdatum'] || '');
+            if (start0 && deadline0) {
+                const map = instByTypeMonth.get(typ) || new Map();
+                addOpenMonthsToInstMap(map, start0.slice(0, 7), deadline0.slice(0, 7), deadline0);
+                instByTypeMonth.set(typ, map);
+                continue;
+            }
             const step = monthsStepFromFreq(f['Frekvens']);
             const map = instByTypeMonth.get(typ) || new Map();
             if (step === 0) {
@@ -1526,6 +1533,25 @@ class CustomerCardManager {
                     }
                     return;
                     }
+                }
+
+                if (isLoneTyp(t) && window.LonePeriod && Array.isArray(runRecords) && runRecords.length) {
+                    const visible = runRecords
+                        .filter((rr) => String(rr?.fields?.['Typ'] || '').trim() === t)
+                        .filter((rr) => LonePeriod.runVisibleInBoardMonth(rr.fields, mk, todayIso));
+                    visible.sort((a, b) => String(a?.fields?.['PeriodKey'] || '').localeCompare(String(b?.fields?.['PeriodKey'] || '')));
+                    visible.forEach((rr) => {
+                        const pk = String(rr?.fields?.['PeriodKey'] || '').trim();
+                        rowContexts.push({
+                            t, rec, f, freq,
+                            boardKey: `${t}|||${pk}`,
+                            displayTitle: LonePeriod.displayLabel(pk, t) || LonePeriod.typDisplayLabel(t),
+                            instDeadline: String(rr?.fields?.['Deadline'] || '').trim(),
+                            prefillPeriodKey: pk,
+                            runRec: rr
+                        });
+                    });
+                    return;
                 }
 
                 const instMap = instByTypeMonth.get(t) || new Map();

--- a/public/js/lone-period.js
+++ b/public/js/lone-period.js
@@ -147,6 +147,21 @@
         return workYm ? isoWithDay(workYm, day) : '';
     }
 
+    /** Visa körning i vald kalendermånad: från startdatum-månad t.o.m. deadline-månad, plus försenade. */
+    function runVisibleInBoardMonth(runFields, boardYm, todayIso) {
+        const status = String(runFields?.Status || '').trim();
+        if (status === 'Klar') return false;
+        const start = toDateStr(runFields?.Startdatum || '');
+        const deadline = toDateStr(runFields?.Deadline || '');
+        if (!boardYm) return false;
+        const startYm = start ? start.slice(0, 7) : '';
+        const endYm = deadline ? deadline.slice(0, 7) : '';
+        if (!startYm || !endYm) return false;
+        if (boardYm >= startYm && boardYm <= endYm) return true;
+        if (todayIso && deadline && todayIso > deadline && boardYm >= startYm) return true;
+        return false;
+    }
+
     global.LonePeriod = {
         TYP_LEGACY,
         TYP_INNEVARANDE,
@@ -162,6 +177,7 @@
         periodKeyFromDeadline,
         deadlineIsoFromPeriodKey,
         startIsoFromPeriodKey,
+        runVisibleInBoardMonth,
         monthAdd,
         monthNameOnly,
         toDateStr


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Augustikörningen ("Lön som ska utbetalas i augusti", start 1 aug – deadline 11 aug) syntes i **juli**-vyn.

Orsaken var att synlighet beräknades som `deadline − 1 månad` i stället för körningens faktiska **Startdatum → Deadline**.

## Fix

- Ny `LonePeriod.runVisibleInBoardMonth()` – samma princip som moms
- Lönekörningar filtreras per vald månad utifrån start- och slutdatum
- `instByTypeMonth` använder `Startdatum`/`Deadline` från körningsraden när de finns

## Resultat

En körning syns bara under månader där den är "öppen" (från startmånad t.o.m. deadlinemånad), plus försenade körningar tills de klarmarkeras.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

