### PR TITLE
Fix: lönekörningar syns bara under öppen period

### DIFF
--- a/public/js/lone-period.js
+++ b/public/js/lone-period.js
@@ -147,8 +147,8 @@
         return workYm ? isoWithDay(workYm, day) : '';
     }
 
-    /** Visa körning i vald kalendermånad: från startdatum-månad t.o.m. deadline-månad, plus försenade. */
-    function runVisibleInBoardMonth(runFields, boardYm, todayIso) {
+    /** Visa körning i vald kalendermånad: endast under öppen period (startdatum → deadline). */
+    function runVisibleInBoardMonth(runFields, boardYm, _todayIso) {
         const status = String(runFields?.Status || '').trim();
         if (status === 'Klar') return false;
         const start = toDateStr(runFields?.Startdatum || '');
@@ -157,9 +157,7 @@
         const startYm = start ? start.slice(0, 7) : '';
         const endYm = deadline ? deadline.slice(0, 7) : '';
         if (!startYm || !endYm) return false;
-        if (boardYm >= startYm && boardYm <= endYm) return true;
-        if (todayIso && deadline && todayIso > deadline && boardYm >= startYm) return true;
-        return false;
+        return boardYm >= startYm && boardYm <= endYm;
     }
 
     global.LonePeriod = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Den första lönekörningen (skapad i juli) syntes i alla efterföljande månader — t.ex. "Lön som ska utbetalas i juli" dök upp även i septembervyn.

## Orsak
`LonePeriod.runVisibleInBoardMonth()` hade en försenad-regel som visade icke-klara körningar i **alla** månader från startdatum och framåt, inklusive framtida månader.

## Lösning
Körningar visas nu endast när vald månad ligger inom öppen period: från startdatum-månad till deadline-månad.

## Test
- Juli-lönekörning syns i juli-vyn
- Juli-lönekörning syns **inte** i augusti/september-vyn
- September-lönekörning syns bara i september-vyn
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

