### PR TITLE
Fix: dubbletter av uppdragskörningar

### DIFF
--- a/index.js
+++ b/index.js
@@ -7110,6 +7110,64 @@ async function ensureUppdragRunsSchema(airtableAccessToken, baseId) {
   } catch (_) {}
 }
 
+function uppdragRunCompositeKey(uppdragId, periodKey) {
+  return `${String(uppdragId || '').trim()}:${String(periodKey || '').trim()}`;
+}
+
+function pickBestUppdragRunRecord(records, expectedRunKey) {
+  const list = Array.isArray(records) ? records.slice() : [];
+  if (!list.length) return null;
+  list.sort((a, b) => {
+    const aKey = String(a?.fields?.['Run Key'] || '').trim();
+    const bKey = String(b?.fields?.['Run Key'] || '').trim();
+    if (expectedRunKey) {
+      if (aKey === expectedRunKey && bKey !== expectedRunKey) return -1;
+      if (bKey === expectedRunKey && aKey !== expectedRunKey) return 1;
+    }
+    if (aKey && !bKey) return -1;
+    if (!aKey && bKey) return 1;
+    const aSk = String(a?.fields?.['Skapad'] || '');
+    const bSk = String(b?.fields?.['Skapad'] || '');
+    return aSk.localeCompare(bSk);
+  });
+  return list[0];
+}
+
+async function dedupeAndIndexUppdragRuns(runList, uppdragId, uppdragRunsUrl, airtableAccessToken) {
+  const groups = new Map();
+  for (const rr of runList || []) {
+    const pk = String(rr?.fields?.['PeriodKey'] || '').trim();
+    if (!pk) continue;
+    const composite = uppdragRunCompositeKey(uppdragId, pk);
+    const arr = groups.get(composite) || [];
+    arr.push(rr);
+    groups.set(composite, arr);
+  }
+
+  const existing = new Map();
+  let deleted = 0;
+  const headers = { Authorization: `Bearer ${airtableAccessToken}` };
+  for (const [composite, arr] of groups) {
+    const keep = pickBestUppdragRunRecord(arr, composite);
+    if (!keep) continue;
+    existing.set(composite, keep);
+    const keepKey = String(keep?.fields?.['Run Key'] || '').trim();
+    if (keepKey) existing.set(keepKey, keep);
+    for (const rr of arr) {
+      if (!rr?.id || rr.id === keep.id) continue;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await axios.delete(`${uppdragRunsUrl}/${rr.id}`, { headers });
+        deleted += 1;
+      } catch (e) {
+        const msg = e.response?.data?.error?.message || e.message;
+        console.warn(`dedupeUppdragRuns: kunde inte ta bort dubblett ${rr.id}:`, msg);
+      }
+    }
+  }
+  return { existing, deleted };
+}
+
 async function ensureRunsAheadForUppdrag(uppdragRec, ctx) {
   const {
     airtableAccessToken,
@@ -7139,13 +7197,13 @@ async function ensureRunsAheadForUppdrag(uppdragRec, ctx) {
 
   if (!uppdragRunsUrl) return { created: 0, skipped: true, reason: 'runs_table_missing' };
 
-  const existing = new Map();
+  let existing = new Map();
+  let deduped = 0;
   try {
     const runList = await fetchRunsForUppdragId(uppdragRunsUrl, uppdragId, airtableAccessToken);
-    runList.forEach(rr => {
-      const key = String(rr?.fields?.['Run Key'] || '').trim();
-      if (key) existing.set(key, rr);
-    });
+    const indexed = await dedupeAndIndexUppdragRuns(runList, uppdragId, uppdragRunsUrl, airtableAccessToken);
+    existing = indexed.existing;
+    deduped = indexed.deleted;
   } catch (_) {}
 
   const grundRutin = String(f['Rutin'] || '').trim();
@@ -7161,6 +7219,7 @@ async function ensureRunsAheadForUppdrag(uppdragRec, ctx) {
       const expectedStart = toIsoDate(startIso || '');
       const currentStart = toIsoDate(existingRun?.fields?.['Startdatum'] || '');
       const patchFields = {};
+      if (!String(existingRun?.fields?.['Run Key'] || '').trim()) patchFields['Run Key'] = runKey;
       if (expectedStart && expectedStart !== currentStart) patchFields['Startdatum'] = expectedStart;
       const runRutin = String(existingRun?.fields?.['Rutin'] || '').trim();
       const forward = isForwardUppdragRun(existingRun?.fields || {}, todayIso);
@@ -7229,7 +7288,7 @@ async function ensureRunsAheadForUppdrag(uppdragRec, ctx) {
         startIso: run.startIso
       });
     }
-    return { created, skipped: false, errors };
+    return { created, deduped, skipped: false, errors };
   }
 
   if (isLoneUppdragTyp(typ) && freqLow.includes('månad')) {
@@ -7246,7 +7305,7 @@ async function ensureRunsAheadForUppdrag(uppdragRec, ctx) {
         startIso: run.startIso
       });
     }
-    return { created, skipped: false, errors };
+    return { created, deduped, skipped: false, errors };
   }
 
   if (freqLow.includes('månad')) {
@@ -7260,7 +7319,7 @@ async function ensureRunsAheadForUppdrag(uppdragRec, ctx) {
       // eslint-disable-next-line no-await-in-loop
       await createRun({ periodKey: ym, periodLabel: monthLabelSv(ym), deadlineIso });
     }
-    return { created, skipped: false, errors };
+    return { created, deduped, skipped: false, errors };
   }
 
   let cur = deadline0;
@@ -7283,7 +7342,7 @@ async function ensureRunsAheadForUppdrag(uppdragRec, ctx) {
     await createRun({ periodKey, periodLabel, deadlineIso: cur });
     cur = calcNextDeadline(cur, freq) || '';
   }
-  return { created, skipped: false, errors };
+  return { created, deduped, skipped: false, errors };
 }
 
 async function buildEnsureRunsContext(airtableAccessToken, baseId) {
@@ -13381,11 +13440,13 @@ app.post('/api/uppdrag/ensure-runs', authenticateToken, async (req, res) => {
 
     const results = [];
     let totalCreated = 0;
+    let totalDeduped = 0;
     for (const rec of records) {
       // eslint-disable-next-line no-await-in-loop
       const r = await ensureRunsForUppdragRecord(rec, airtableAccessToken, airtableBaseId);
       results.push({ uppdragId: rec.id, typ: rec?.fields?.['Typ'] || '', ...r });
       totalCreated += Number(r?.created || 0);
+      totalDeduped += Number(r?.deduped || 0);
     }
 
     return res.json({
@@ -13393,6 +13454,7 @@ app.post('/api/uppdrag/ensure-runs', authenticateToken, async (req, res) => {
       customerId: customerId || null,
       processed: results.length,
       totalCreated,
+      totalDeduped,
       results
     });
   } catch (error) {

--- a/public/js/kundkort.js
+++ b/public/js/kundkort.js
@@ -964,6 +964,14 @@ class CustomerCardManager {
             this.showNotification(`${successLabel}, men körningar kunde inte skapas: ${re.errors[0].message}`, 'error');
             return;
         }
+        if ((re.deduped || 0) > 0 && (re.created || 0) > 0) {
+            this.showNotification(`${successLabel} – ${re.created} körning(ar) skapade, ${re.deduped} dubblett(er) borttagna ✅`, 'success');
+            return;
+        }
+        if ((re.deduped || 0) > 0) {
+            this.showNotification(`${successLabel} – ${re.deduped} dubblett(er) borttagna ✅`, 'success');
+            return;
+        }
         if ((re.created || 0) > 0) {
             this.showNotification(`${successLabel} – ${re.created} körning(ar) skapade ✅`, 'success');
             return;
@@ -1464,6 +1472,25 @@ class CustomerCardManager {
                 const sel = String(selected || '').trim();
                 return opts.map(o => `<option value="${this._esc(o)}" ${o === sel ? 'selected' : ''}>${this._esc(o)}</option>`).join('');
             };
+            const dedupeRunsByPeriodKey = (runs, typ, visibleFn) => {
+                const best = new Map();
+                (Array.isArray(runs) ? runs : []).forEach((rr) => {
+                    if (String(rr?.fields?.['Typ'] || '').trim() !== typ) return;
+                    if (visibleFn && !visibleFn(rr)) return;
+                    const pk = String(rr?.fields?.['PeriodKey'] || '').trim();
+                    if (!pk) return;
+                    const prev = best.get(pk);
+                    if (!prev) {
+                        best.set(pk, rr);
+                        return;
+                    }
+                    const prevKey = String(prev?.fields?.['Run Key'] || '').trim();
+                    const curKey = String(rr?.fields?.['Run Key'] || '').trim();
+                    if (!prevKey && curKey) best.set(pk, rr);
+                });
+                return Array.from(best.values());
+            };
+
             const rowContexts = [];
             existingTypes.forEach((t) => {
                 const rec = byType(t);
@@ -1487,9 +1514,8 @@ class CustomerCardManager {
                     defaultPeriodKey = momsDefaultPeriodKey;
                     if (MomsPeriod.isMonthlyFreq(momsFreq) || MomsPeriod.isQuarterlyFreq(momsFreq)) {
                     const momsRunTitle = (periodKey) => MomsPeriod.runTitle(periodKey, momsFreq, mk);
-                    let visible = (Array.isArray(runRecords) ? runRecords : [])
-                        .filter((rr) => String(rr?.fields?.['Typ'] || '').trim() === 'Momsredovisning')
-                        .filter((rr) => MomsPeriod.runVisibleInBoardMonth(rr.fields, mk, todayIso));
+                    let visible = dedupeRunsByPeriodKey(runRecords, 'Momsredovisning', (rr) =>
+                        MomsPeriod.runVisibleInBoardMonth(rr.fields, mk, todayIso));
                     visible.sort((a, b) => String(a?.fields?.['PeriodKey'] || '').localeCompare(String(b?.fields?.['PeriodKey'] || '')));
                     if (!visible.length) {
                         let pk = MomsPeriod.defaultPeriodKeyForBoard(mk, momsFreq);
@@ -1536,9 +1562,8 @@ class CustomerCardManager {
                 }
 
                 if (isLoneTyp(t) && window.LonePeriod && Array.isArray(runRecords) && runRecords.length) {
-                    const visible = runRecords
-                        .filter((rr) => String(rr?.fields?.['Typ'] || '').trim() === t)
-                        .filter((rr) => LonePeriod.runVisibleInBoardMonth(rr.fields, mk, todayIso));
+                    const visible = dedupeRunsByPeriodKey(runRecords, t, (rr) =>
+                        LonePeriod.runVisibleInBoardMonth(rr.fields, mk, todayIso));
                     visible.sort((a, b) => String(a?.fields?.['PeriodKey'] || '').localeCompare(String(b?.fields?.['PeriodKey'] || '')));
                     visible.forEach((rr) => {
                         const pk = String(rr?.fields?.['PeriodKey'] || '').trim();
@@ -2014,7 +2039,12 @@ class CustomerCardManager {
                     const data = await res.json().catch(() => ({}));
                     if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
                     const n = Number(data.totalCreated || 0);
-                    this.showNotification(n > 0 ? `${n} körning(ar) skapade ✅` : 'Körningar är redan uppdaterade', n > 0 ? 'success' : 'info');
+                    const d = Number(data.totalDeduped || 0);
+                    let msg = 'Körningar är redan uppdaterade';
+                    if (n > 0 && d > 0) msg = `${n} körning(ar) skapade, ${d} dubblett(er) borttagna ✅`;
+                    else if (n > 0) msg = `${n} körning(ar) skapade ✅`;
+                    else if (d > 0) msg = `${d} dubblett(er) borttagna ✅`;
+                    this.showNotification(msg, (n > 0 || d > 0) ? 'success' : 'info');
                     this.loadUppdrag();
                 } catch (e) {
                     this.showNotification('Kunde inte generera körningar: ' + (e.message || 'fel'), 'error');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Samma lönekörning visades flera gånger i uppdragsvyn (t.ex. 6 identiska rader för juni-lön i juli-vyn).

## Orsak
Körningar deduplicerades bara via fältet `Run Key` i Airtable. Om fältet saknades (t.ex. vid tidigare schema-problem) skapades en ny körning vid varje sparning/generering.

## Lösning
- Indexera befintliga körningar även på `Uppdrag ID` + `PeriodKey`
- Ta bort dubbletter i Airtable vid ensure-runs (behåller bästa posten)
- Fyll i saknad `Run Key` på befintliga körningar
- Deduplicera i UI som extra skydd

## Efter deploy
Öppna kundkortet och klicka **Generera körningar** (eller spara uppdraget) – dubbletter rensas då i Airtable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

