### PR TITLE
Fix: visa klara uppdragskörningar i Uppdragsfliken

### DIFF
--- a/public/js/kundkort.js
+++ b/public/js/kundkort.js
@@ -1976,8 +1976,10 @@ class CustomerCardManager {
                     )
                     : `<span class="uppdragboard-progress" style="opacity:.65;">Ingen körning</span>`;
 
+                const isKlar = runStatus === 'Klar';
+
                 return `
-                <tr class="uppdragboard-row ${isOpen ? 'is-open' : ''}" data-kund-board-key="${this._esc(boardKey)}" data-kund-board-typ="${this._esc(t)}">
+                <tr class="uppdragboard-row ${isOpen ? 'is-open' : ''} ${isKlar ? 'is-done' : ''}" data-kund-board-key="${this._esc(boardKey)}" data-kund-board-typ="${this._esc(t)}">
                     <td>
                         <div class="uppdragboard-client">
                             <span class="uppdragboard-link">${this._esc(displayTitle)}</span>

--- a/public/js/lone-period.js
+++ b/public/js/lone-period.js
@@ -149,8 +149,6 @@
 
     /** Visa körning i vald kalendermånad: endast under öppen period (startdatum → deadline). */
     function runVisibleInBoardMonth(runFields, boardYm, _todayIso) {
-        const status = String(runFields?.Status || '').trim();
-        if (status === 'Klar') return false;
         const start = toDateStr(runFields?.Startdatum || '');
         const deadline = toDateStr(runFields?.Deadline || '');
         if (!boardYm) return false;

--- a/public/js/moms-period.js
+++ b/public/js/moms-period.js
@@ -276,8 +276,6 @@
 
     /** Visa körning i vald kalendermånad (bräda): från månaden efter momsperiod t.o.m. deadline, plus försenade. */
     function runVisibleInBoardMonth(runFields, boardYm, todayIso) {
-        const status = String(runFields?.Status || '').trim();
-        if (status === 'Klar') return false;
         const pk = String(runFields?.PeriodKey || '').trim();
         const deadline = String(runFields?.Deadline || '').trim().slice(0, 10);
         const freq = runFields?.Frekvens || 'Varje månad';

--- a/public/styles.css
+++ b/public/styles.css
@@ -8519,6 +8519,14 @@ textarea.kunduppgifter-input.uppdrag-run-note[readonly] {
     color: var(--success);
 }
 
+.uppdragboard-row.is-done td {
+    opacity: 0.72;
+}
+
+.uppdragboard-row.is-done .uppdragboard-link {
+    color: var(--success);
+}
+
 .uppdrag-run-status-select {
     min-width: 180px;
     max-width: 260px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Uppdragskörningar med status **Klar** försvann från Uppdragsfliken direkt efter att de markerats klara.

## Orsak
`runVisibleInBoardMonth()` i `lone-period.js` och `moms-period.js` returnerade `false` för alla körningar med status Klar.

## Lösning
- Ta bort Klar-filtret från månadssynligheten
- Klara körningar syns kvar under sin period (startdatum → deadline)
- Nedtonad grön styling (`is-done`) visar att körningen är klar

Rutin-snapshot och propagering påverkas inte — klara körningar behandlas fortfarande som avslutade där.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0841f85f-7ba4-4d70-9905-c588ed03f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

